### PR TITLE
ci: add jsonnet config

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -20,7 +20,7 @@ local r_env_vars = {
 # generally, only the second element should be modified
 local ci_images = [
   "mpn-dev:latest",      # latest MPN snapshot
-  "mpn-dev:2020-03-24",  # oldest compatible snapshot
+  "mpn-dev:2020-06-08",  # oldest compatible snapshot
   "cran-latest:latest",  # latest MPN snapshot for MRG packages + current CRAN
 ];
 


### PR DESCRIPTION
This PR points Drone at the new `mpn-dev` and `cran-latest` CI images. We also switch to a Jsonnet-style Drone configuration.

The Jsonnet configuration and the set of images were tested in metrumresearchgroup/rbabylon#111.

- The oldest compatible MPN snapshot is expected to vary by package. Currently it is set to 2020-03-24. Is that correct?

- `.drone.jsonnet` includes a linting pipeline. This is temporarily disabled to avoid an overall build failure. We should separately discuss enabling it, and any overrides to the default linting rules.

- We will eventually deprecate `.drone.yml`.

I have pointed Drone at the Jsonnet configuration. The effect will be that all CI builds (regardless of branch) will use the Jsonnet configuration. Any open PRs will need to be rebased on dev to pull in `.drone.jsonnet`.

FYI @evol262 @bkyoung @dpastoor

