### PR TITLE
fix: add aws to release since not present on image

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -319,7 +319,7 @@ local release(name, r_major_minor, image) =
           "R_LIBS_USER": "/opt/rpkgs/" + r_major_minor,
         },
         "commands": [
-          "pip install --upgrade awscli"
+          "pip install --upgrade awscli",
           # git config needs to sit next to pkgpub
           "git config --global user.email " + default_git_email,
           "git config --global user.name " + default_git_user,


### PR DESCRIPTION
FYI, current mpn-dev images do not have aws - resulting in tags failing:

https://github-drone.metrumrg.com/metrumresearchgroup/pmtables/702/4/4