### PR TITLE
ci: fix release pipeline

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -354,6 +354,7 @@ local release(name, r_major_minor, image) =
         ],
       },
       s3_publish_tag("${DRONE_TAG}", "${DRONE_TAG}", temp_volume),
+      s3_publish_tag("${DRONE_TAG}", "latest_tag", temp_volume),
     ],
   };
 


### PR DESCRIPTION
This PR fixes the release pipeline. As noted in #110, the AWS CLI is not available in the `mpn-dev` or `cran-latest` images. Rather than installing the CLI in the pipeline, or rebuilding the images to include it, this PR uses the [AWS S3 plugin](http://plugins.drone.io/drone-plugins/drone-s3/) to publish the `pkgpub` artifact to S3. The expected workflow is

1. user tags commit: `git tag -a foo -m "my fine tag"`
2. user pushes tags, triggering a Drone build: `git push origin --tags`
3. the tag event triggers the release pipeline
4. the release pipeline creates a CRAN-like repo structure containing the package artifact
5. the release pipeline pushes this repo to S3 at `mpn.metworx.dev/releases/pmtables/foo`

This approach was tested in metrumresearchgroup/matrixbuilds@f2c4610. [This Drone build](https://github-drone.metrumrg.com/metrumresearchgroup/matrixbuilds/139) shows the build for the associated tag event, and the artifact is available [on S3](https://s3.console.aws.amazon.com/s3/buckets/mpn.metworx.dev/releases/matrixbuilds/0.0.0.9001/?region=us-east-1&tab=overview).

Note that the Jsonnet can be rendered to YAML with

```sh
drone jsonnet --stream --stdout --source path/to/.drone.jsonnet
```

If the working directory contains `.drone.jsonnet`, the `--source` argument can be omitted.

For reference, I initially tried the [AWS S3 Sync](http://plugins.drone.io/drone-plugins/drone-s3-sync/) plugin, but there appears to be some issue with volumes. Specifically, `source: /tmp/foo` is resolved as `/drone/src/tmp/foo`.

FYI @bkyoung @evol262 @kylebaron 