### PR TITLE
don't coerce to character in st2doc st_wrap

### DIFF
--- a/R/preview.R
+++ b/R/preview.R
@@ -25,17 +25,18 @@ st2doc <- function(text, preview = TRUE, output_dir = tempdir(), # nocov start
 
   if(is.list(text)) {
     tab <- map(text, .f = function(this_table) {
-      this_table <- as.character(this_table)
       if(!any(grepl("begin{table}", this_table, fixed = TRUE))) {
-        this_table <- pt_wrap(as.character(this_table))
+        this_table <- st_wrap(this_table, con = NULL)
       }
       c(this_table, "\\clearpage")
     })
     tab <- flatten_chr(tab)
   } else {
-    tab <- as.character(text)
-    if(!any(grepl("begin{table}", tab, fixed = TRUE))) {
-      tab <- pt_wrap(as.character(tab))
+    assert_that(is.character(text))
+    if(!any(grepl("begin{table}", text, fixed = TRUE))) {
+      tab <- st_wrap(text, con = NULL)
+    } else {
+      tab <- text
     }
   }
 


### PR DESCRIPTION
- st2doc was coercing object to character so that it wasn't dispatching to the right wrap method
- this is fixed now
- force con to be NULL so that it doesn't send to stdout
- this enables long tables to be handled correctly