### PR TITLE
add test for sanitizing prior to bold

### DIFF
--- a/R/table-cols.R
+++ b/R/table-cols.R
@@ -81,6 +81,9 @@ header_matrix <- function(cols, cols_new, units = NULL, newline = "...",
   u <- header_matrix_unit(sp, cols, units)
   nunit <- !map_int(u, is.null)
   nrows <- max(nsplit+nunit)
+  esc <- getOption("pmtables.escape", c("_", "%"))
+  sp <- map(sp, tab_escape, escape = esc)
+  u <- map(u, tab_escape, escape = esc)
   if(isTRUE(bold)) {
     sp <- map(sp, bold_each)
   }
@@ -95,8 +98,6 @@ header_matrix <- function(cols, cols_new, units = NULL, newline = "...",
 header_matrix_tex <- function(sp, sizes = tab_size()) {
   sp <- unname(split(sp, seq(nrow(sp))))
   sp <- map(sp, flatten_chr)
-  esc <- getOption("pmtables.escape", c("_", "%"))
-  sp <- map(sp, tab_escape, escape = esc)
   sp <- map_chr(sp, form_tex_cols)
   nr <- length(sp)
   header_space <- sizes$header_row

--- a/tests/testthat/test-tab_cols.R
+++ b/tests/testthat/test-tab_cols.R
@@ -48,6 +48,13 @@ test_that("cols are bold", {
   expect_false(grepl("textbf", x$cols_tex))
 })
 
+test_that("cols are bold after sanitizing", {
+  data <- tibble(a_z = 1, b = 2, c = 3)
+  x <- inspect(data, cols_bold = TRUE)
+  cols <- str_split(x$cols_tex, " *& *")
+  expect_equal(cols[[1]][1], "\\textbf{a\\_z}")
+})
+
 test_that("units", {
   u <- list(b = "in",kyle = "baron", dd = 5, a = "mg")
   data <- tibble(a = 1, b = 2, c = 3)


### PR DESCRIPTION
See #141 

- Sanitize after columns are re-named
- When bold markup is applied, names are already sanitized