### PR TITLE
Return invisible; some refactors for preview

### DIFF
--- a/R/preview.R
+++ b/R/preview.R
@@ -102,6 +102,9 @@ st_preview <- function(x,...) { # nocov start
   if(inherits(x, what = c("pmtable", "stobject"))) {
     x <- as_stable(x)
   }
+  if(inherits(x, what = "stable_long")) {
+    stop("cannot preview long tables in the viewer window", call.=FALSE)
+  }
   assert_that(requireNamespace("texPreview"))
   if(length(x) > 1) {
     x <- paste0(x,collapse = "\n")
@@ -109,11 +112,12 @@ st_preview <- function(x,...) { # nocov start
   pk <- texPreview::build_usepackage(
     c("threeparttable", "array", "booktabs")
   )
-  texPreview::tex_preview(
+  foo <- texPreview::tex_preview(
     x,
     usrPackages = pk,
     ...
   )
+  return(invisible(x))
 } # nocov end
 
 #' @rdname st_preview
@@ -194,6 +198,9 @@ st2viewer <- function(...) st_preview(...)
 #'   pmtables::st2article(tab)
 #' }
 #'
+#' @return
+#' A list of the table inputs, invisibly.
+#'
 #' @export
 st2article <- function(..., .list = NULL, ntex = 1,  #nocov start
                        stem = "view-st2article",
@@ -201,7 +208,7 @@ st2article <- function(..., .list = NULL, ntex = 1,  #nocov start
                        margin = "3cm", caption = NULL,
                        dry_run = FALSE, stdout = FALSE, show_pdf = TRUE) {
 
-  tables <- c(list(...),.list)
+  tables <-inputs <- c(list(...),.list)
   output_dir <- normalizePath(output_dir)
   build_dir <- normalizePath(tempdir())
   assert_that(dir.exists(output_dir))
@@ -300,7 +307,7 @@ st2article <- function(..., .list = NULL, ntex = 1,  #nocov start
     }
   }
 
-  return(invisible(ans))
+  return(invisible(inputs))
 } # nocov end
 
 #' @rdname st2article

--- a/R/preview.R
+++ b/R/preview.R
@@ -205,7 +205,7 @@ st2viewer <- function(...) st_preview(...)
 st2article <- function(..., .list = NULL, ntex = 1,  #nocov start
                        stem = "view-st2article",
                        output_dir = tempdir(), template = NULL,
-                       margin = "3cm", caption = NULL,
+                       margin = c("2.54cm", "3cm"), caption = NULL,
                        dry_run = FALSE, stdout = FALSE, show_pdf = TRUE) {
 
   tables <-inputs <- c(list(...),.list)

--- a/R/table-tabular.R
+++ b/R/table-tabular.R
@@ -71,8 +71,6 @@ make_tabular <- function(data, prime_fun = tab_prime,
 
   data <- prime_fun(data, escape_fun)
 
-  data <- as.data.frame(data)
-
   tab <- modify(data, function(x) {
     formatC(x, width = max(nchar(x)))
   })

--- a/R/table-utils.R
+++ b/R/table-utils.R
@@ -9,7 +9,9 @@
 #'
 #' @export
 stable_save <- function(x, file = attr(x, "stable_file"), dir = getOption("pmtables.dir")) {
-
+  if(inherits(x, "list")) {
+    return(map(x, stable_save, dir = dir))
+  }
   if(!inherits(x, "stable")) {
     stop(
       "bad input - x is not an 'stable' object; ",

--- a/R/table-utils.R
+++ b/R/table-utils.R
@@ -4,6 +4,9 @@
 #' @param file the file
 #' @param dir the directory where the file is to be saved
 #'
+#' @return
+#' The `stable` or `stable_long` object is returned invisibly.
+#'
 #' @export
 stable_save <- function(x, file = attr(x, "stable_file"), dir = getOption("pmtables.dir")) {
 
@@ -27,6 +30,7 @@ stable_save <- function(x, file = attr(x, "stable_file"), dir = getOption("pmtab
     file <- file.path(dir,file)
   }
   writeLines(text = x, con = file)
+  return(invisible(x))
 }
 
 insrt_vec <- function(vec, nw, where) {

--- a/man/st2article.Rd
+++ b/man/st2article.Rd
@@ -68,6 +68,8 @@ set \code{stdout = ""} and you'll see the output in the R console}
 If \code{dry_run} is \code{FALSE}, then a list (invisible) containing the document
 template as \code{doc} and the table data as \code{tables}. If \code{dry_run} is \code{TRUE},
 then the \code{doc} and \code{tables} are returned visibly (see \code{dry_run} argument).
+
+A list of the table inputs, invisibly.
 }
 \description{
 Use \code{\link[=st2article]{st2article()}} to see tables in a plain pdf TeX document. Use

--- a/man/stable_save.Rd
+++ b/man/stable_save.Rd
@@ -13,6 +13,9 @@ stable_save(x, file = attr(x, "stable_file"), dir = getOption("pmtables.dir"))
 
 \item{dir}{the directory where the file is to be saved}
 }
+\value{
+The \code{stable} or \code{stable_long} object is returned invisibly.
+}
 \description{
 Save output from stable
 }

--- a/tests/testthat/test-preview.R
+++ b/tests/testthat/test-preview.R
@@ -36,3 +36,7 @@ test_that("st-wrap table placement H", {
   expect_match(out2[2], "{table}[H]", fixed = TRUE)
   pmtables:::st_reset_knit_deps()
 })
+
+test_that("error to try to view long table", {
+  expect_error(st2viewer(stable_long(stdata)))
+})

--- a/tests/testthat/test-table-utils.R
+++ b/tests/testthat/test-table-utils.R
@@ -24,7 +24,8 @@ test_that("tex_bold and tex_it", {
 test_that("test-table-utils-stable_save", {
   tmp <- tempfile()
   x <- stable(data.frame(a = 1), output_file = tmp)
-  stable_save(x)
+  expect_invisible(ans <- stable_save(x))
+  expect_equal(ans, x)
   expect_true(file.exists(tmp))
   read <- readLines(tmp)
   expect_identical(as.character(x), read)

--- a/tests/testthat/test-table-utils.R
+++ b/tests/testthat/test-table-utils.R
@@ -35,6 +35,14 @@ test_that("test-table-utils-stable_save", {
   expect_error(stable_save(x), "and the 'file' argument is missing")
 })
 
+test_that("save a list of tables", {
+  a <- stable(stdata(), output_file = "a.tex")
+  b <- stable(stdata(), output_file = "b.tex")
+  l <- list(a,b)
+  ans <- stable_save(l)
+  expect_is(ans, "list")
+})
+
 test_that("table-utils paste units", {
   cols <- LETTERS[c(2,5,4,3,1)]
   units <- list(C = "pounds", X = "none", B = "mg", D = "kg", Z = "liters")


### PR DESCRIPTION
#193 #181 

# Summary
- generate error if you try to texPreview a long table
- return `stable` or `stable_long` object  invisibly form `stable_save`
- `st2article` now returns input tables as a list / invisibly
-  When a list is passed to `stable_save` we'll map across that and try to save what is in that list; we pass only`.dir` - file names will have to come from the object