### PR TITLE
escape list names

### DIFF
--- a/R/preview.R
+++ b/R/preview.R
@@ -210,6 +210,7 @@ st2article <- function(..., .list = NULL, ntex = 1,  #nocov start
 
   tables <- c(list(...),.list)
   tables <- flatten_if(tables, is.list)
+  names(tables) <- tab_escape(names(tables))
   inputs <- tables
   output_dir <- normalizePath(output_dir)
   build_dir <- normalizePath(tempdir())

--- a/tests/testthat/test-preview.R
+++ b/tests/testthat/test-preview.R
@@ -51,3 +51,9 @@ test_that("pass a list of tables to st2report", {
   expect_length(ans2, 3)
 })
 
+test_that("st2report - list names are escaped", {
+  l <- list(a = stable(stdata()), `a_b` = stable(stdata()))
+  a <- st2report(l, dry_run = TRUE)
+  expect_equal(
+    names(a), c("a", "a\\_b"))
+})


### PR DESCRIPTION
# Summary

This escapes the names of the table list passed to `st2report()`.  Issue #232  