### PR TITLE
Feature/reverse split

### DIFF
--- a/R/table-span.R
+++ b/R/table-span.R
@@ -6,13 +6,25 @@
 #' @param level relative position for the grouping spanner; level 0 is the
 #' column names; level 1 is one step away (up) from the column names, etc
 #' @param sep character on which to split column names
-#'
+#' @param split logical; if `TRUE` column groupings will be determined by
+#' splitting columns names on a separator
+#' @param sep character; the separator used for finding column groupings
+#' @param title_from which side of the split should be taken as the `title`?
+#' defaults to `.left` but can also take the `.right` side of the splits
 #' @return an object with class `colgroup`
 #' @export
-colgroup <- function(title = NULL, vars = c(), level = 1, sep = ".", split = FALSE) {
+colgroup <- function(title = NULL, vars = c(), level = 1, sep = ".",
+                     split = FALSE, title_from = c(".left", ".right")) {
 
   if(isTRUE(split)) {
-    return(colsplit(title = title, level = level, sep = sep, split = TRUE))
+    ans <- colsplit(
+      title = title,
+      level = level,
+      sep = sep,
+      split = TRUE,
+      title_from = title_from
+    )
+    return(ans)
   }
 
   assert_that(is.character(title))
@@ -33,20 +45,23 @@ colgroup <- function(title = NULL, vars = c(), level = 1, sep = ".", split = FAL
 as.span <- colgroup
 
 #' @rdname colgroup
-#' @param split logical; if `TRUE` column groupings will be determined by
-#' splitting columns names on a separator
-#' @param sep character; the separator used for finding column groupings
 #' @export
-colsplit <- function(sep, level = 1, split = TRUE, title = NULL) {
+colsplit <- function(sep, level = 1, split = TRUE, title = NULL,
+                     title_from = c(".left", ".right")) {
   assert_that(is.null(title) || is.list(title))
-  if(!is.null(title)) assert_that(is_named(title))
+  if(is.list(title)) {
+    assert_that(is_named(title))
+  }
+  title_from <- match.arg(title_from)
+  tagn <- ifelse(title_from == ".left", 1, 2)
   structure(
     list(
       title = title,
       level = level,
       split = split,
       sep = sep,
-      gather = FALSE
+      gather = FALSE,
+      tagn = tagn
     ),
     class = "colsplit"
   )
@@ -109,13 +124,22 @@ combine_spans <- function(..., cols) {
 
 find_span_split <- function(cols,xsp) {
   x <- str_split(cols, fixed(xsp$sep), n = 2)
+
+  sp <- list(
+    newcol = map_chr(x, last),
+    tag = map_chr(x, first)
+  )
+  if(xsp$tagn ==2) {
+    names(sp) <- rev(names(sp))
+  }
   spans <- tibble(
     coln = seq_along(x),
     col = cols,
-    newcol = map_chr(x,last),
-    tag  = map_chr(x,1),
+    newcol = sp$newcol,
+    tag  = sp$tag,
     tagf = fct_inorder(.data[["tag"]])
   )
+
   if(xsp$gather) spans <- arrange(spans, .data[["tagf"]])
   spans <- mutate(
     spans,
@@ -132,7 +156,8 @@ find_span_split <- function(cols,xsp) {
   spans <- map(spans, ~ c(.x$tag[1],.x$col[1],.x$col[nrow(.x)]))
   resort <- !identical(spandf$coln,seq_len(nrow(spandf)))
 
-  if(!is.null(xsp$title)) {
+  # title is a list to rename
+  if(is.list(xsp$title)) {
     assert_that(rlang::is_named(xsp$title))
     title <- spandf$tag
     if(!all(names(xsp$title) %in% title)) {

--- a/R/table-span.R
+++ b/R/table-span.R
@@ -10,7 +10,7 @@
 #' splitting columns names on a separator
 #' @param sep character; the separator used for finding column groupings
 #' @param title_side which side of the split should be taken as the `title`?
-#' defaults to `.left` but can also take the `.right` side of the splits
+#' defaults to left (`.l`) but can also take the right (`.r`) side of the split
 #' @return an object with class `colgroup`
 #' @export
 colgroup <- function(title = NULL, vars = c(), level = 1, sep = ".",

--- a/R/table-span.R
+++ b/R/table-span.R
@@ -9,12 +9,12 @@
 #' @param split logical; if `TRUE` column groupings will be determined by
 #' splitting columns names on a separator
 #' @param sep character; the separator used for finding column groupings
-#' @param title_from which side of the split should be taken as the `title`?
+#' @param title_side which side of the split should be taken as the `title`?
 #' defaults to `.left` but can also take the `.right` side of the splits
 #' @return an object with class `colgroup`
 #' @export
 colgroup <- function(title = NULL, vars = c(), level = 1, sep = ".",
-                     split = FALSE, title_from = c(".left", ".right")) {
+                     split = FALSE, title_side = c(".l", ".r")) {
 
   if(isTRUE(split)) {
     ans <- colsplit(
@@ -22,7 +22,7 @@ colgroup <- function(title = NULL, vars = c(), level = 1, sep = ".",
       level = level,
       sep = sep,
       split = TRUE,
-      title_from = title_from
+      title_side = title_side
     )
     return(ans)
   }
@@ -47,13 +47,13 @@ as.span <- colgroup
 #' @rdname colgroup
 #' @export
 colsplit <- function(sep, level = 1, split = TRUE, title = NULL,
-                     title_from = c(".left", ".right")) {
+                     title_side = c(".l", ".r")) {
   assert_that(is.null(title) || is.list(title))
   if(is.list(title)) {
     assert_that(is_named(title))
   }
-  title_from <- match.arg(title_from)
-  tagn <- ifelse(title_from == ".left", 1, 2)
+  title_side <- match.arg(title_side)
+  tagn <- ifelse(title_side == ".l", 1, 2)
   structure(
     list(
       title = title,

--- a/man/colgroup.Rd
+++ b/man/colgroup.Rd
@@ -52,7 +52,7 @@ column names; level 1 is one step away (up) from the column names, etc}
 splitting columns names on a separator}
 
 \item{title_side}{which side of the split should be taken as the \code{title}?
-defaults to \code{.left} but can also take the \code{.right} side of the splits}
+defaults to left (\code{.l}) but can also take the right (\code{.r}) side of the split}
 
 \item{x}{an R object}
 }

--- a/man/colgroup.Rd
+++ b/man/colgroup.Rd
@@ -8,11 +8,31 @@
 \alias{is.colsplit}
 \title{Set spans to group columns}
 \usage{
-colgroup(title = NULL, vars = c(), level = 1, sep = ".", split = FALSE)
+colgroup(
+  title = NULL,
+  vars = c(),
+  level = 1,
+  sep = ".",
+  split = FALSE,
+  title_from = c(".left", ".right")
+)
 
-as.span(title = NULL, vars = c(), level = 1, sep = ".", split = FALSE)
+as.span(
+  title = NULL,
+  vars = c(),
+  level = 1,
+  sep = ".",
+  split = FALSE,
+  title_from = c(".left", ".right")
+)
 
-colsplit(sep, level = 1, split = TRUE, title = NULL)
+colsplit(
+  sep,
+  level = 1,
+  split = TRUE,
+  title = NULL,
+  title_from = c(".left", ".right")
+)
 
 is.colgroup(x)
 
@@ -30,6 +50,9 @@ column names; level 1 is one step away (up) from the column names, etc}
 
 \item{split}{logical; if \code{TRUE} column groupings will be determined by
 splitting columns names on a separator}
+
+\item{title_from}{which side of the split should be taken as the \code{title}?
+defaults to \code{.left} but can also take the \code{.right} side of the splits}
 
 \item{x}{an R object}
 }

--- a/man/colgroup.Rd
+++ b/man/colgroup.Rd
@@ -14,7 +14,7 @@ colgroup(
   level = 1,
   sep = ".",
   split = FALSE,
-  title_from = c(".left", ".right")
+  title_side = c(".l", ".r")
 )
 
 as.span(
@@ -23,7 +23,7 @@ as.span(
   level = 1,
   sep = ".",
   split = FALSE,
-  title_from = c(".left", ".right")
+  title_side = c(".l", ".r")
 )
 
 colsplit(
@@ -31,7 +31,7 @@ colsplit(
   level = 1,
   split = TRUE,
   title = NULL,
-  title_from = c(".left", ".right")
+  title_side = c(".l", ".r")
 )
 
 is.colgroup(x)
@@ -51,7 +51,7 @@ column names; level 1 is one step away (up) from the column names, etc}
 \item{split}{logical; if \code{TRUE} column groupings will be determined by
 splitting columns names on a separator}
 
-\item{title_from}{which side of the split should be taken as the \code{title}?
+\item{title_side}{which side of the split should be taken as the \code{title}?
 defaults to \code{.left} but can also take the \code{.right} side of the splits}
 
 \item{x}{an R object}

--- a/tests/testthat/test-span.R
+++ b/tests/testthat/test-span.R
@@ -14,6 +14,16 @@ test_that("span split", {
   expect_equal(out$span_data$span[[1]]$title, c("a", "a", "", "z", "z"))
 })
 
+test_that("span split with reversed title / col", {
+  data1 <- data.frame(a.A = 1, a.B = 2, C = 3, z.Y = 4, z.Z = 5)
+  data2 <- data.frame(A.a = 1, B.a = 2, C = 3, Y.z = 4, Z.z = 5)
+  out1 <- inspect(data1, span_split = colsplit(sep = '.'))
+  out2 <- inspect(data2, span_split = colsplit(sep = '.', title_side = ".r"))
+  expect_identical(out1$output, out2$output)
+  expect_equal(out2$cols_new, c("A", "B", "C", "Y", "Z"))
+  expect_equal(out2$span_data$span[[1]]$title, c("a", "a", "", "z", "z"))
+})
+
 test_that("span split with title", {
   data <- data.frame(a.A = 1, a.B = 2, C = 3, z.Y = 4, z.Z = 5)
   title <- list(a = "First Split", z = "Last Split")


### PR DESCRIPTION
# Summary 

- you can (already) split column names on a separator to form the span title (left) and column name (right)
- this PR  adds `title_side` argument to `colsplit()` so you can take the title from the right and column name from the left
- this came out of an actual problem I had on a project

Issue #231 