### PR TITLE
Add jut and nopagebreak as panel options

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Suggests: testthat, yaml, fs, texPreview
 Encoding: UTF-8
 Language: en-US
 LazyData: true
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
 Collate: 

--- a/R/AAAA.R
+++ b/R/AAAA.R
@@ -26,6 +26,7 @@ NULL
 
 # GLOBAL object
 .internal <- new.env(parent = emptyenv())
+.internal$marker.panel <- "%--pmtables-insert-panel"
 
 .onLoad <- function(libname, pkgname) {
   st_reset_knit_deps()

--- a/R/table-long.R
+++ b/R/table-long.R
@@ -1,11 +1,7 @@
-head <- '
-\\endhead
-\\hline
-\\multicolumn{<nc>}{r}{<lt_continue>}
-\\endfoot
-\\hline
-\\endlastfoot
-'
+
+lontable_head <- function(multicol) {
+  c("\\endhead", "\\hline", multicol, "\\endfoot", "\\hline", "\\endlastfoot")
+}
 
 ltcaption <- function(macro = "", text = "", short = "", label = "") {
   if(identical(c(macro, text, short), c("", "", ""))) {
@@ -87,8 +83,9 @@ stable_long.data.frame <- function(data,
   row_space <- gluet("\\renewcommand{\\arraystretch}{<x$sizes$row_space>}")
   col_space <- gluet("\\setlength{\\tabcolsep}{<x$sizes$col_space>pt} ")
 
-  nc <- x$nc
-  head <- gluet(head)
+  n_col <- x$nc
+  continued <- gluet("\\multicolumn{<n_col>}{r}{<lt_continue>}")
+  head <- longtable_head(continued)
 
   lt_notes <- longtable_notes(x$mini_notes)
 

--- a/R/table-long.R
+++ b/R/table-long.R
@@ -38,6 +38,12 @@ longtable_notes <- function(notes) {
 
 #' Create longtable output from an R data frame
 #'
+#' Use this function to allow your table to span multiple pages, with a
+#' "to be continued" statement at the bottom of each page. There are important
+#' differences between this `longtable` environment and the `tabular`
+#' environment that is used to generate tables from [stable()]. See the
+#' `details` section for more information.
+#'
 #' @inheritParams tab_notes
 #' @param data an object to render as a long table; this could be a `data.frame`,
 #' a `pmtable` object or an `stobject`; when passing in a `data.frame`, the data
@@ -53,6 +59,30 @@ longtable_notes <- function(notes) {
 #' @param lt_cap_label table label for use in latex document
 #' @param lt_continue longtable continuation message
 #'
+#' @details
+#'
+#' To create `longtable` output, `pmtables` first passes the data frame
+#' through [stable()] and then modifies the output to create a table in
+#' `longtable` environment. The `...` arguments to [stable_long()] are passed
+#' to [stable()] and can be used to configure the table. One important difference
+#' between `tablular` and `longtable` environments is that captions need to
+#' get inserted **inside** the `longtable` environment; this is why you see
+#' several additional arguments for [stable_long()].
+#'
+#' You may have to run `pdflatex` on your `longtable` more than once to get the
+#' table to render properly; this is not unexpected behavior for `longtable`.
+#'
+#' If you have panels in your table, the default is to prevent page breaks
+#' right after the panel title row using the `\\*` command in the `longtable`
+#' package. This shouldn't need to be changed by the user, but if needed this
+#' can be suppressed by adding `nopagebreak = FALSE` when calling [as.panel()]
+#' or [rowgroups()].
+#'
+#' @return A character vector with the TeX code for the table with `class`
+#' attribute set to `stable_long` and `stable`.
+#'
+#' @examples
+#' stable_long(stdata())
 #'
 #' @export
 stable_long <- function(data, ...) UseMethod("stable_long")
@@ -90,7 +120,7 @@ stable_long.data.frame <- function(data,
   lt_notes <- longtable_notes(x$mini_notes)
 
   # Put stars on panel rows for long tables
-  if(!x$panel$null) {
+  if(!x$panel$null && x$panel$nopagebreak) {
     x$tab <- tab_panel_star(x$tab)
   }
 

--- a/R/table-long.R
+++ b/R/table-long.R
@@ -1,5 +1,5 @@
 
-lontable_head <- function(multicol) {
+longtable_head <- function(multicol) {
   c("\\endhead", "\\hline", multicol, "\\endfoot", "\\hline", "\\endlastfoot")
 }
 
@@ -88,6 +88,11 @@ stable_long.data.frame <- function(data,
   head <- longtable_head(continued)
 
   lt_notes <- longtable_notes(x$mini_notes)
+
+  # Put stars on panel rows for long tables
+  if(!x$panel$null) {
+    x$tab <- tab_panel_star(x$tab)
+  }
 
   longtab <- c(
     x$sizes$font_size$start,

--- a/R/table-long.R
+++ b/R/table-long.R
@@ -76,7 +76,7 @@ longtable_notes <- function(notes) {
 #' right after the panel title row using the `\\*` command in the `longtable`
 #' package. This shouldn't need to be changed by the user, but if needed this
 #' can be suppressed by adding `nopagebreak = FALSE` when calling [as.panel()]
-#' or [rowgroups()].
+#' or [rowpanel()].
 #'
 #' @return A character vector with the TeX code for the table with `class`
 #' attribute set to `stable_long` and `stable`.

--- a/R/table-panel.R
+++ b/R/table-panel.R
@@ -15,6 +15,8 @@
 #' @param it render panel title in italic font face
 #' @param hline logical indicating whether or not to draw an `hline` above
 #' the panel row; the first panel row never receives an `hline`
+#' @param jut amount (in TeX `ex` units) by which the panel headers are
+#' outdented from the first column in the main table
 #'
 #' @seealso [as.panel()]
 #'
@@ -22,7 +24,8 @@
 rowpanel <- function(col = NULL, prefix = "", skip = ".panel.skip.",
                      prefix_name = FALSE,
                      prefix_skip = NULL, duplicates_ok = FALSE,
-                     bold = TRUE, it = FALSE, hline = TRUE) {
+                     bold = TRUE, it = FALSE, hline = TRUE,
+                     jut = 0) {
   null <- FALSE
   if(is.null(col)) {
     col <- NULL
@@ -34,7 +37,8 @@ rowpanel <- function(col = NULL, prefix = "", skip = ".panel.skip.",
   ans <- list(
     col = col, prefix = prefix, prefix_name = isTRUE(prefix_name),
     prefix_skip = prefix_skip, null = null, dup_err = !isTRUE(duplicates_ok),
-    bold = isTRUE(bold), it = isTRUE(it), skip = skip, hline = isTRUE(hline)
+    bold = isTRUE(bold), it = isTRUE(it), skip = skip, hline = isTRUE(hline),
+    jut = jut
   )
   structure(ans, class = "rowpanel")
 }
@@ -109,7 +113,7 @@ panel_by <- function(data, x) {
       "panel labels are duplicated; ",
       "please sort the data frame by the panel column ",
       "or set duplicates_ok to TRUE",
-      call.=FALSE
+      call. = FALSE
     )
   }
   prefix <- rep(prefix, length(lab))
@@ -174,7 +178,3 @@ tab_panel_insert <- function(tab, panel_insert) {
     nw = panel_insert$insert_data
   )
 }
-
-
-
-

--- a/R/table-panel.R
+++ b/R/table-panel.R
@@ -176,6 +176,22 @@ tab_panel_insert <- function(tab, panel_insert) {
   insrt_vec(
     vec = tab,
     where = panel_insert$insert_row,
-    nw = panel_insert$insert_data
+    nw = tab_panel_mark(panel_insert$insert_data)
   )
+}
+
+tab_panel_marker <- function() {
+  .internal$marker.panel
+}
+
+tab_panel_mark <- function(x) {
+  paste0(x, tab_panel_marker())
+}
+
+tab_panel_star <- function(x) {
+  marker <- tab_panel_marker()
+  where <- grepl(marker, x, fixed = TRUE)
+  if(!any(where)) return(x)
+  x[where] <- sub(marker, paste0("*", marker), x[where], fixed = TRUE)
+  x
 }

--- a/R/table-panel.R
+++ b/R/table-panel.R
@@ -16,7 +16,8 @@
 #' @param hline logical indicating whether or not to draw an `hline` above
 #' the panel row; the first panel row never receives an `hline`
 #' @param jut amount (in TeX `ex` units) by which the panel headers are
-#' outdented from the first column in the main table
+#' outdented from the first column in the main table and header. Consider
+#' using a value of `2` for a clear offset.
 #'
 #' @seealso [as.panel()]
 #'

--- a/R/table-panel.R
+++ b/R/table-panel.R
@@ -18,6 +18,11 @@
 #' @param jut amount (in TeX `ex` units) by which the panel headers are
 #' outdented from the first column in the main table and header. Consider
 #' using a value of `2` for a clear offset.
+#' @param nopagebreak if `TRUE` (the default) then the page will not break
+#' immediately after a panel title _when creating a longtable_; this argument
+#' does nothing if you are not generating a `longtable`. Set to `FALSE` to
+#' prevent the `nopagebreak` command (implemented as `*`) in the longtable
+#' output.
 #'
 #' @seealso [as.panel()]
 #'
@@ -26,7 +31,7 @@ rowpanel <- function(col = NULL, prefix = "", skip = ".panel.skip.",
                      prefix_name = FALSE,
                      prefix_skip = NULL, duplicates_ok = FALSE,
                      bold = TRUE, it = FALSE, hline = TRUE,
-                     jut = 0) {
+                     jut = 0, nopagebreak = TRUE) {
   null <- FALSE
   if(is.null(col)) {
     col <- NULL
@@ -39,7 +44,7 @@ rowpanel <- function(col = NULL, prefix = "", skip = ".panel.skip.",
     col = col, prefix = prefix, prefix_name = isTRUE(prefix_name),
     prefix_skip = prefix_skip, null = null, dup_err = !isTRUE(duplicates_ok),
     bold = isTRUE(bold), it = isTRUE(it), skip = skip, hline = isTRUE(hline),
-    jut = jut
+    jut = jut, nopagebreak = isTRUE(nopagebreak)
   )
   structure(ans, class = "rowpanel")
 }

--- a/R/table-panel.R
+++ b/R/table-panel.R
@@ -40,6 +40,8 @@ rowpanel <- function(col = NULL, prefix = "", skip = ".panel.skip.",
   } else {
     col <- new_names(col)
   }
+  assert_that(is.numeric(jut))
+  assert_that(is.character(skip))
   ans <- list(
     col = col, prefix = prefix, prefix_name = isTRUE(prefix_name),
     prefix_skip = prefix_skip, null = null, dup_err = !isTRUE(duplicates_ok),

--- a/R/table-stable.R
+++ b/R/table-stable.R
@@ -236,7 +236,6 @@ stable.data.frame <- function(data,
   row_space <- gluet("\\renewcommand{\\arraystretch}{<sizes$row_space>}")
   col_space <- gluet("\\setlength{\\tabcolsep}{<sizes$col_space>pt} ")
 
-
   out <- c(
     sizes$font_size$start,
     col_space,

--- a/R/table-stable.R
+++ b/R/table-stable.R
@@ -216,8 +216,19 @@ stable.data.frame <- function(data,
   # add hlines
   tab <- tab_add_hlines(tab, add_hlines, sumrows)
 
+  # indent if paneled
+  tab <- indent_tex(tab, panel$jut)
+
   # execute panel insertions
   tab <- tab_panel_insert(tab, panel_insert)
+
+  # Table header
+  head_rows <- form_headrows(
+    span_data,
+    cols_tex,
+    cols_data,
+    indent = panel$jut
+  )
 
   # notes
   note_data <- tab_notes(notes, escape_fun = escape_fun,  ...)
@@ -225,7 +236,6 @@ stable.data.frame <- function(data,
   row_space <- gluet("\\renewcommand{\\arraystretch}{<sizes$row_space>}")
   col_space <- gluet("\\setlength{\\tabcolsep}{<sizes$col_space>pt} ")
 
-  head_rows <- form_headrows(span_data, cols_tex, cols_data)
 
   out <- c(
     sizes$font_size$start,

--- a/R/table-tabular.R
+++ b/R/table-tabular.R
@@ -109,7 +109,7 @@ form_open <- function(align) {
 }
 
 # all the rows above top headline for rows
-form_headrows <- function(span_data, cols_tex, cols_data) {
+form_headrows <- function(span_data, cols_tex, cols_data, indent = 0) {
   hl1 <-  hl2 <- "\\hline"
   if(cols_data$omit) {
     cols_tex <- NULL
@@ -119,5 +119,10 @@ form_headrows <- function(span_data, cols_tex, cols_data) {
       hl2 <- NULL
     }
   }
-  c(hl1, span_data$tex, cols_tex, hl2)
+  ans <- c(span_data$tex, cols_tex)
+  if(indent > 0) {
+    ans <- indent_tex(ans, indent)
+  }
+  c(hl1, ans, hl2)
 }
+

--- a/R/table-utils.R
+++ b/R/table-utils.R
@@ -165,3 +165,9 @@ paste_units <- function(cols, units) {
   }
   cols
 }
+
+indent_tex <- function(x, n) {
+  if(n == 0) return(x)
+  prefix <- paste0("\\hskip ", n, "ex ")
+  paste0(prefix, x)
+}

--- a/man/rowpanel.Rd
+++ b/man/rowpanel.Rd
@@ -14,7 +14,8 @@ rowpanel(
   duplicates_ok = FALSE,
   bold = TRUE,
   it = FALSE,
-  hline = TRUE
+  hline = TRUE,
+  outdent = 0
 )
 
 is.rowpanel(x)
@@ -41,6 +42,9 @@ panel will have the same header}
 
 \item{hline}{logical indicating whether or not to draw an \code{hline} above
 the panel row; the first panel row never receives an \code{hline}}
+
+\item{outdent}{amount (in TeX \code{ex} units) by which the panel headers are
+exdented}
 
 \item{x}{an object to test}
 }

--- a/man/rowpanel.Rd
+++ b/man/rowpanel.Rd
@@ -15,7 +15,7 @@ rowpanel(
   bold = TRUE,
   it = FALSE,
   hline = TRUE,
-  outdent = 0
+  jut = 0
 )
 
 is.rowpanel(x)
@@ -43,8 +43,9 @@ panel will have the same header}
 \item{hline}{logical indicating whether or not to draw an \code{hline} above
 the panel row; the first panel row never receives an \code{hline}}
 
-\item{outdent}{amount (in TeX \code{ex} units) by which the panel headers are
-exdented}
+\item{jut}{amount (in TeX \code{ex} units) by which the panel headers are
+outdented from the first column in the main table and header. Consider
+using a value of \code{2} for a clear offset.}
 
 \item{x}{an object to test}
 }

--- a/man/rowpanel.Rd
+++ b/man/rowpanel.Rd
@@ -15,7 +15,8 @@ rowpanel(
   bold = TRUE,
   it = FALSE,
   hline = TRUE,
-  jut = 0
+  jut = 0,
+  nopagebreak = TRUE
 )
 
 is.rowpanel(x)
@@ -46,6 +47,12 @@ the panel row; the first panel row never receives an \code{hline}}
 \item{jut}{amount (in TeX \code{ex} units) by which the panel headers are
 outdented from the first column in the main table and header. Consider
 using a value of \code{2} for a clear offset.}
+
+\item{nopagebreak}{if \code{TRUE} (the default) then the page will not break
+immediately after a panel title \emph{when creating a longtable}; this argument
+does nothing if you are not generating a \code{longtable}. Set to \code{FALSE} to
+prevent the \code{nopagebreak} command (implemented as \code{*}) in the longtable
+output.}
 
 \item{x}{an object to test}
 }

--- a/man/stable_long.Rd
+++ b/man/stable_long.Rd
@@ -77,7 +77,7 @@ If you have panels in your table, the default is to prevent page breaks
 right after the panel title row using the \verb{\\\\*} command in the \code{longtable}
 package. This shouldn't need to be changed by the user, but if needed this
 can be suppressed by adding \code{nopagebreak = FALSE} when calling \code{\link[=as.panel]{as.panel()}}
-or \code{\link[=rowgroups]{rowgroups()}}.
+or \code{\link[=rowpanel]{rowpanel()}}.
 }
 \examples{
 stable_long(stdata())

--- a/man/stable_long.Rd
+++ b/man/stable_long.Rd
@@ -50,6 +50,36 @@ lead with \verb{\\\\} - this will be added for you}
 
 \item{lt_continue}{longtable continuation message}
 }
+\value{
+A character vector with the TeX code for the table with \code{class}
+attribute set to \code{stable_long} and \code{stable}.
+}
 \description{
-Create longtable output from an R data frame
+Use this function to allow your table to span multiple pages, with a
+"to be continued" statement at the bottom of each page. There are important
+differences between this \code{longtable} environment and the \code{tabular}
+environment that is used to generate tables from \code{\link[=stable]{stable()}}. See the
+\code{details} section for more information.
+}
+\details{
+To create \code{longtable} output, \code{pmtables} first passes the data frame
+through \code{\link[=stable]{stable()}} and then modifies the output to create a table in
+\code{longtable} environment. The \code{...} arguments to \code{\link[=stable_long]{stable_long()}} are passed
+to \code{\link[=stable]{stable()}} and can be used to configure the table. One important difference
+between \code{tablular} and \code{longtable} environments is that captions need to
+get inserted \strong{inside} the \code{longtable} environment; this is why you see
+several additional arguments for \code{\link[=stable_long]{stable_long()}}.
+
+You may have to run \code{pdflatex} on your \code{longtable} more than once to get the
+table to render properly; this is not unexpected behavior for \code{longtable}.
+
+If you have panels in your table, the default is to prevent page breaks
+right after the panel title row using the \verb{\\\\*} command in the \code{longtable}
+package. This shouldn't need to be changed by the user, but if needed this
+can be suppressed by adding \code{nopagebreak = FALSE} when calling \code{\link[=as.panel]{as.panel()}}
+or \code{\link[=rowgroups]{rowgroups()}}.
+}
+\examples{
+stable_long(stdata())
+
 }

--- a/tests/testthat/test-panel.R
+++ b/tests/testthat/test-panel.R
@@ -82,3 +82,50 @@ test_that("omit hline from panel", {
   expect_match(tab1[where], "\\hline", fixed = TRUE)
   expect_false(grepl("\\hline", tab2[where], fixed = TRUE))
 })
+
+test_that("nopagebreak for panels in longtable", {
+  ans <- stable_long(stdata(), panel = "STUDY")
+  inserted <- grep(pmtables:::.internal$marker.panel, ans, fixed = TRUE)
+  check <- grep("DEMO", ans, fixed = TRUE)
+  expect_identical(inserted, check)
+  expect_match(
+    ans[inserted],
+    "\\\\*",
+    fixed = TRUE
+  )
+  ans <- stable_long(stdata(), panel = as.panel("STUDY", nopagebreak = FALSE))
+  inserted <- grep(pmtables:::.internal$marker.panel, ans, fixed = TRUE)
+  expect_no_match(
+    ans[inserted],
+    "\\\\*",
+    fixed = TRUE
+  )
+})
+
+test_that("jut de-indents panel rows", {
+  u <- list(WT = "kg")
+  ans <- inspect(stdata(), panel = rowpanel("STUDY", jut = 1), units = u)
+  code <- ans$output
+  tab <- ans$tab
+  header <- ans$head_rows
+  header <- header[-c(1, length(header))]
+  panels <- grepl("DEMO", tab, fixed = TRUE)
+  expect_match(
+    tab[!panels],
+    "\\hskip 1ex",
+    fixed = TRUE
+  )
+  expect_no_match(
+    tab[panels],
+    "\\hskip 1ex",
+    fixed = TRUE
+  )
+  expect_match(
+    header,
+    "\\hskip 1ex",
+    fixed = TRUE
+  )
+  indented <- c(header, tab[!panels])
+  pick <- code[grep("hskip", code)]
+  expect_identical(indented, skip)
+})


### PR DESCRIPTION
# Summary
- add `jut` argument to `rowpanel()` to shift non-panel rows; units are `ex`
- add `nopagebreak` argument to `rowpanel()`; default is `TRUE` and results in `\\*` getting added to panel rows to 
when rendering `longtable` prevent page breaks (in `longtable` environment only)
- panel rows are marked by a commented tag, stored in the `.internal` environment
- Filled in documentation for `longtable` and added **simple** example

# Example - jut
<img width="739" alt="Screen Shot 2021-12-21 at 12 15 30 PM" src="https://user-images.githubusercontent.com/16908301/146978840-6cd56e18-297f-43e7-a1e6-89185aa12025.png">

# Example - nopagebreak

```
> stable_long(data1, panel = "STUDY")
....                                                                 
[11] "\\hline"                                                                        
[12] "DOSE & FORM & N & WT & CRCL & AGE & ALB & SCR \\\\"                             
[13] "\\hline"                                                                        
[14] "\\endfirsthead"                                                                 
[15] "\\hline"                                                                        
[16] "DOSE & FORM & N & WT & CRCL & AGE & ALB & SCR \\\\"                             
[17] "\\hline"                                                                        
[18] "\\endhead"                                                                      
[19] "\\hline"                                                                        
[20] "\\multicolumn{8}{l}{\\textbf{12-DEMO-001}}\\\\*%--pmtables-insert-panel"        
[21] "100 mg & tablet & 80 & 71.4 & 104 & 33.7 & 4.20 & 1.06 \\\\"                    
[22] "150 mg & capsule & 16 & 89.4 & 122 & 24.4 & 4.63 & 1.12 \\\\"                   
[23] "150 mg & tablet & 48 & 81.7 & 104 & 34.4 & 3.83 & 0.910 \\\\"                   
[24] "150 mg & troche & 16 & 94.0 & 93.2 & 27.4 & 4.94 & 1.25 \\\\"                   
[25] "200 mg & tablet & 64 & 67.9 & 100 & 27.5 & 4.25 & 1.10 \\\\"                    
[26] "200 mg & troche & 16 & 76.6 & 99.2 & 22.8 & 4.54 & 1.15 \\\\"                   
[27] "\\hline \\multicolumn{8}{l}{\\textbf{12-DEMO-002}}\\\\*%--pmtables-insert-panel"
[28] "100 mg & capsule & 36 & 61.3 & 113 & 38.3 & 4.04 & 1.28 \\\\"                   
[29] "100 mg & tablet & 324 & 77.6 & 106 & 29.9 & 4.31 & 0.981 \\\\"                  
[30] "50 mg & capsule & 36 & 74.1 & 112 & 37.1 & 4.44 & 0.900 \\\\"                   
[31] "50 mg & tablet & 324 & 71.2 & 106 & 34.1 & 4.63 & 0.868 \\\\"                   
[32] "75 mg & capsule & 36 & 72.4 & 105 & 38.2 & 3.89 & 0.900 \\\\"                   
[33] "75 mg & tablet & 288 & 71.6 & 98.9 & 34.2 & 4.49 & 0.991 \\\\"                  
[34] "75 mg & troche & 36 & 73.6 & 103 & 49.2 & 4.52 & 0.930 \\\\"                    
[35] "\\hline"                                                                        
[36] "\\end{longtable}"                                                               
attr(,"class")
[1] "stable_long" "stable"     
```
