### PR TITLE
as_image: move unit tests to test file

### DIFF
--- a/tests/testthat/image/as-image-test.Rmd
+++ b/tests/testthat/image/as-image-test.Rmd
@@ -13,13 +13,8 @@ knitr::opts_chunk$set(echo = TRUE)
 library(dplyr)
 library(knitr)
 library(pmtables)
-library(testthat)
 
 dir <- "build"
-
-standalone <- function() {
-  readLines(file.path(dir, "standalone-preview.tex"))  
-}
 ```
 
 
@@ -64,46 +59,24 @@ brokentab[4] <- ""
 
 ```{r}
 st_as_image(tab, dir = dir, stem = "convert-stable")
-
-x <- standalone()
-
-expect_match(x, "convert-stable.tex", all = FALSE, fixed = TRUE)
-expect_match(x, "helvet", all = FALSE, fixed = TRUE)
-expect_match(x, "\\textwidth}{6.5in}", all = FALSE, fixed = TRUE)
-expect_match(x, "varwidth=6.5in", all = FALSE, fixed = TRUE)
-expect_match(x, "\\usepackage{longtable}[=v4.13]", all = FALSE, fixed = TRUE)
-expect_match(x, "\\rule{6.5in}{0pt}", all = FALSE, fixed = TRUE)
-expect_match(x, "border={0.2cm 0.7cm}", all = FALSE, fixed = TRUE)
 ```
 
 ## Convert from long stable
 
 ```{r}
 st_as_image(longtab, dir = dir, stem = "convert-longtable", ntex = 2)
-
-x <- standalone()
-
-expect_match(x, "\\input{convert-longtable.tex}", all = FALSE, fixed = TRUE)
 ```
 
 ## Convert from pmtable
 
 ```{r}
 st_as_image(pttab, dir = dir, stem = "convert-pttab")
-
-x <- standalone()
-
-expect_match(x, "\\input{convert-pttab.tex}", all = FALSE, fixed = TRUE)
 ```
 
 ## Convert from stobject
 
 ```{r}
 st_as_image(sttab, dir = dir, stem = "convert-sttab")
-
-x <- standalone()
-
-expect_match(x, "\\input{convert-sttab.tex}", all = FALSE, fixed = TRUE)
 ```
 
 
@@ -112,66 +85,36 @@ expect_match(x, "\\input{convert-sttab.tex}", all = FALSE, fixed = TRUE)
 ```{r}
 file <- st_aspng(tab, dir = dir, stem = "include-from-png")
 include_graphics(file)
-
-x <- standalone()
-
-expect_match(x, "\\input{include-from-png.tex}", all = FALSE, fixed = TRUE)
 ```
 
 ## Make the page smaller
 
 ```{r}
 st_as_image(tab, dir = dir, stem = "smaller-page", textwidth = 4)
-
-x <- standalone()
-
-expect_match(x, "\\textwidth}{4in}", all = FALSE, fixed = TRUE)
-expect_match(x, "varwidth=4in", all = FALSE, fixed = TRUE)
-expect_match(x, "\\rule{4in}{0pt}", all = FALSE, fixed = TRUE)
-expect_match(x, "\\input{smaller-page.tex}", all = FALSE, fixed = TRUE)
 ```
 
 ## Make display width smaller
 
 ```{r}
 st_as_image(tab, dir = dir, stem = "smaller-width", width = 0.5)
-
-x <- standalone()
-
-expect_match(x, "\\textwidth}{6.5in}", all = FALSE, fixed = TRUE)
-expect_match(x, "varwidth=6.5in", all = FALSE, fixed = TRUE)
-expect_match(x, "\\rule{6.5in}{0pt}", all = FALSE, fixed = TRUE)
-expect_match(x, "\\input{smaller-width.tex}", all = FALSE, fixed = TRUE)
 ```
 
 ## Bigger border on the top
 
 ```{r}
 st_as_image(tab, dir = dir, stem = "bigger-border", border = "0.2cm 3cm")
-
-x <- standalone()
-expect_match(x, "border={0.2cm 3cm}", all = FALSE, fixed = TRUE)
-expect_match(x, "\\input{bigger-border.tex}", all = FALSE, fixed = TRUE)
 ```
 
 ## Change the font - utopia
 
 ```{r}
 st_as_image(tab, dir = dir, stem = "test-utopia", font = "utopia")
-
-x <- standalone()
-
-expect_match(x, "utopia", all = FALSE, fixed = TRUE)
 ```
 
 ## Change the font - roboto
 
 ```{r}
 st_as_image(tab, dir = dir, stem = "test-roboto", font = "roboto")
-
-x <- standalone()
-
-expect_match(x, "roboto", all = FALSE, fixed = TRUE)
 ```
 
 ## Broken pdf

--- a/tests/testthat/test-as-image.R
+++ b/tests/testthat/test-as-image.R
@@ -1,0 +1,84 @@
+
+do <- function(fn, ...) {
+  output_dir <- tempfile("pmtables-test-")
+  dir.create(output_dir)
+  on.exit(unlink(output_dir), add = TRUE)
+  old_dir <- setwd(output_dir)
+  on.exit(setwd(old_dir), add = TRUE, after = FALSE)
+
+  args <- list(..., dir = output_dir)
+  do.call(fn, args)
+
+  return(readLines("standalone-preview.tex"))
+}
+
+test_that("standalone tex file looks as expected: stable", {
+  tab <- stable(stdata())
+  x <- do(st_as_image, tab, stem = "convert-stable")
+  expect_match(x, "convert-stable.tex", all = FALSE, fixed = TRUE)
+  expect_match(x, "helvet", all = FALSE, fixed = TRUE)
+  expect_match(x, "\\textwidth}{6.5in}", all = FALSE, fixed = TRUE)
+  expect_match(x, "varwidth=6.5in", all = FALSE, fixed = TRUE)
+  expect_match(x, "\\usepackage{longtable}[=v4.13]", all = FALSE, fixed = TRUE)
+  expect_match(x, "\\rule{6.5in}{0pt}", all = FALSE, fixed = TRUE)
+  expect_match(x, "border={0.2cm 0.7cm}", all = FALSE, fixed = TRUE)
+})
+
+test_that("standalone tex file looks as expected: long stable", {
+  longtab <- stable_long(stdata())
+  x <- do(st_as_image, longtab, stem = "convert-longtable", ntex = 2)
+  expect_match(x, "\\input{convert-longtable.tex}", all = FALSE, fixed = TRUE)
+})
+
+test_that("standalone tex file looks as expected: pmtable", {
+  pttab <- pt_cat_long(pmt_first, span = "STUDYf", cols = "SEXf")
+  x <- do(st_as_image, pttab, stem = "convert-pttab")
+  expect_match(x, "\\input{convert-pttab.tex}", all = FALSE, fixed = TRUE)
+})
+
+test_that("standalone tex file looks as expected: stobject", {
+  sttab <- st_new(stdata())
+  x <- do(st_as_image, sttab, stem = "convert-sttab")
+  expect_match(x, "\\input{convert-sttab.tex}", all = FALSE, fixed = TRUE)
+})
+
+test_that("standalone tex file looks as expected: png", {
+  tab <- stable(stdata())
+  x <- do(st_aspng, tab, stem = "include-from-png")
+  expect_match(x, "\\input{include-from-png.tex}", all = FALSE, fixed = TRUE)
+})
+
+test_that("standalone tex file looks as expected: smaller page", {
+  tab <- stable(stdata())
+  x <- do(st_as_image, tab, stem = "smaller-page", textwidth = 4)
+  expect_match(x, "\\textwidth}{4in}", all = FALSE, fixed = TRUE)
+  expect_match(x, "varwidth=4in", all = FALSE, fixed = TRUE)
+  expect_match(x, "\\rule{4in}{0pt}", all = FALSE, fixed = TRUE)
+  expect_match(x, "\\input{smaller-page.tex}", all = FALSE, fixed = TRUE)
+})
+
+test_that("standalone tex file looks as expected: smaller width", {
+  tab <- stable(stdata())
+  x <- do(st_as_image, tab, stem = "smaller-width", width = 0.5)
+  expect_match(x, "\\textwidth}{6.5in}", all = FALSE, fixed = TRUE)
+  expect_match(x, "varwidth=6.5in", all = FALSE, fixed = TRUE)
+  expect_match(x, "\\rule{6.5in}{0pt}", all = FALSE, fixed = TRUE)
+  expect_match(x, "\\input{smaller-width.tex}", all = FALSE, fixed = TRUE)
+})
+
+test_that("standalone tex file looks as expected: bigger border", {
+  tab <- stable(stdata())
+  x <- do(st_as_image, tab, stem = "bigger-border", border = "0.2cm 3cm")
+  expect_match(x, "border={0.2cm 3cm}", all = FALSE, fixed = TRUE)
+  expect_match(x, "\\input{bigger-border.tex}", all = FALSE, fixed = TRUE)
+})
+
+test_that("standalone tex file looks as expected: change font", {
+  tab <- stable(stdata())
+
+  x <- do(st_as_image, tab, stem = "test-utopia", font = "utopia")
+  expect_match(x, "utopia", all = FALSE, fixed = TRUE)
+
+  x <- do(st_as_image, tab, stem = "test-roboto", font = "roboto")
+  expect_match(x, "roboto", all = FALSE, fixed = TRUE)
+})


### PR DESCRIPTION
Put the unit tests in a standard test file rather than the Rmd so that
the tests are executed by the CI.  The price is some duplication
between the Rmd and test file.