### PR TITLE
is_str_regex: account for stringr 1.5.0 class change

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -120,7 +120,10 @@ is_regex <- function(x) {
 
 is_str_regex <- function(x) {
   if(!is.character(x)) return(FALSE)
-  is_regex(x) || (inherits(x, "fixed") && inherits(x, "pattern"))
+  is_regex(x) ||
+    (inherits(x, "stringr_fixed") && inherits(x, "stringr_pattern")) ||
+    # stringr < v1.5.0
+    (inherits(x, "fixed") && inherits(x, "pattern"))
 }
 
 as_str_regex <- function(x) {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -30,9 +30,14 @@ test_that("check if regular expression is valid [PMT-TEST-0243]", {
   expect_false(pmtables:::is_regex("\\textbf{foo}"))
   expect_true(pmtables:::is_str_regex(fixed("\\textbf{foo}")))
   x <- pmtables:::as_str_regex("\\textbf{foo}")
-  expect_is(x, "fixed")
+  expected <- if (utils::packageVersion("stringr") >= "1.5.0") {
+    "stringr_fixed"
+  } else {
+    "fixed"
+  }
+  expect_is(x, expected)
   x <- pmtables:::as_str_regex(NULL)
-  expect_is(x, "fixed")
+  expect_is(x, expected)
   expect_match(x, "invalid-regex-")
 })
 


### PR DESCRIPTION
The class of pattern modifiers has changed with stringr's 2895a6b (Use stringr_ class prefixes for pattern modifiers, 2022-01-18), part of the v1.5.0 release.

---

This popped up in MPN's check failures.   With this patch, checks pass with either stringr 1.5.0 and 1.4.1.

@kylebaron It seemed easy enough to stay backward compatible here, but let me know if you would instead prefer to just bump the stringr version constraint in DESCRIPTION.