### PR TITLE
silence tidyselect deprecation warnings

### DIFF
--- a/R/data_inventory_table.R
+++ b/R/data_inventory_table.R
@@ -100,14 +100,14 @@ data_inventory_chunk <- function(data, by, panel = by, stacked = FALSE,
     summ,
     !!sym(by),
     !!sym(panel),
-    .data[["SUBJ"]],
-    .data[["NMISS"]],
-    .data[["NOBS"]],
-    .data[["NBQL"]],
-    .data[["POBS"]],
-    .data[["PBQL"]],
-    .data[["OOBS"]],
-    .data[["OBQL"]]
+    "SUBJ",
+    "NMISS",
+    "NOBS",
+    "NBQL",
+    "POBS",
+    "PBQL",
+    "OOBS",
+    "OBQL"
   )
   summ <- ungroup(summ)
   summ <- mutate(summ, !!sym(by) := as.character(!!sym(by)))
@@ -369,26 +369,26 @@ pt_data_inventory <- function(data, by = ".total", panel = by,
   if(inner_summary) {
     ans <- rename(
       ans,
-      `Group percent.OBS` = .data[["POBS"]],
-      `Group percent.BQL` = .data[["PBQL"]],
-      `Overall percent.OBS` = .data[["OOBS"]],
-      `Overall percent.BQL` = .data[["OBQL"]]
+      `Group percent.OBS` = "POBS",
+      `Group percent.BQL` = "PBQL",
+      `Overall percent.OBS` = "OOBS",
+      `Overall percent.BQL` = "OBQL"
     )
   } else {
     ans <- rename(
       ans,
-      `Percent.OBS` = .data[["OOBS"]],
-      `Percent.BQL` = .data[["OBQL"]]
+      `Percent.OBS` = "OOBS",
+      `Percent.BQL` = "OBQL"
     )
     ans <- mutate(ans, POBS = NULL, PBQL = NULL)
   }
 
   ans <- rename(
     ans,
-    Number.SUBJ = .data[["SUBJ"]],
-    Number.MISS = .data[["NMISS"]],
-    Number.OBS = .data[["NOBS"]],
-    Number.BQL = .data[["NBQL"]]
+    Number.SUBJ = "SUBJ",
+    Number.MISS = "NMISS",
+    Number.OBS = "NOBS",
+    Number.BQL = "NBQL"
   )
 
   if(bq_col == "BLQ") {

--- a/R/demographics-table.R
+++ b/R/demographics-table.R
@@ -241,7 +241,7 @@ pt_demographics <- function(data, cols_cont, cols_cat,
   if(summarize_span) {
     cat_table <- pt_cat_long(
       data,
-      cols = all_of(cols_cat),
+      cols = cols_cat,
       span = span,
       summarize = "top",
       denom = denom
@@ -250,7 +250,7 @@ pt_demographics <- function(data, cols_cont, cols_cat,
   if(summarize_all) {
     cat_table_all0 <- pt_cat_long(
       data,
-      cols = all_of(cols_cat),
+      cols = cols_cat,
       summarize = "top",
       denom = denom
     )

--- a/R/demographics-table.R
+++ b/R/demographics-table.R
@@ -278,9 +278,9 @@ pt_demographics <- function(data, cols_cont, cols_cat,
   }
   # Combined Table ###
   table_data <- bind_rows(cont_df, cat_df)
-  table_data <- rename(table_data, !!sym(stat_name) := .data[["level"]])
+  table_data <- rename(table_data, !!sym(stat_name) := "level")
   if(summarize_all) {
-    table_data <- rename(table_data, !!sym(all_name) := .data[["value"]])
+    table_data <- rename(table_data, !!sym(all_name) := "value")
   }
   # add units
   units <- validate_units(units, data)
@@ -315,7 +315,7 @@ pt_demographics <- function(data, cols_cont, cols_cat,
     ans[["hline_from"]] <- "Covariate"
     table_data <- select(
       table_data,
-      Covariate = .data[["name"]],
+      Covariate = "name",
       everything()
     )
   }

--- a/R/demographics-table.R
+++ b/R/demographics-table.R
@@ -335,7 +335,7 @@ demo_summarize_cont <- function(data, span, cols, fun) {
   cont_table <- pivot_wider(
     cont_table,
     names_from  = "name",
-    values_from = summary_names,
+    values_from = all_of(summary_names),
     names_glue  = "{name}_{.value}"
   )
   cont_table <- pivot_longer(cont_table, -!!sym(span))

--- a/R/discrete_table.R
+++ b/R/discrete_table.R
@@ -369,7 +369,7 @@ pt_cat_wide <- function(data, cols, by = ".total", panel = by,
   ans[[".total"]] <- NULL
 
   if("N" %in% names(ans)) {
-    ans <- rename(ans, n = .data[["N"]])
+    ans <- rename(ans, n = "N")
   }
 
   .panel <- rowpanel(NULL)

--- a/R/summarize-cat-chunk.R
+++ b/R/summarize-cat-chunk.R
@@ -35,7 +35,7 @@ summarize_cat_chunk <- function(data, cols, N, denom = "group") {
 #' @noRd
 summarize_cat_col <- function(name, data, D, Nchunk) {
   data <- ungroup(data)
-  pick <- select(data, .data[["ID"]], level = all_of(unname(name)))
+  pick <- select(data, "ID", level = all_of(unname(name)))
   pick <- mutate(pick, name = .env[["name"]])
   pick <- group_by(pick, .data[["name"]], .data[["level"]], .drop = FALSE)
   summ <- summarise(pick, n = n())


### PR DESCRIPTION
Running the test suite with the most recent tidyselect (1.2.0, released 2022/10) leads to a good number of warnings.  This series silences all of those.  I've confirmed that the tests pass with tidyselect 1.1.2 and 1.2.0.

More information: https://www.tidyverse.org/blog/2022/10/tidyselect-1-2-0/#using-data-inside-selections
