### PR TITLE
Set option for maxex argument to sig

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -46,7 +46,7 @@ cvec_cs <- function(x) {
 #' @md
 #' @rdname sig
 #' @export
-sig <- function(x, digits = 3, maxex = NULL, ...) {
+sig <- function(x, digits = 3, maxex = getOption("pmtables.maxex", NULL), ...) {
 
   if(identical(class(x), "integer")) {
     return(as.character(x))

--- a/man/sig.Rd
+++ b/man/sig.Rd
@@ -6,7 +6,7 @@
 \alias{rnd}
 \title{Format digits}
 \usage{
-sig(x, digits = 3, maxex = NULL, ...)
+sig(x, digits = 3, maxex = getOption("pmtables.maxex", NULL), ...)
 
 digit1(x, ...)
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,3 +1,4 @@
+library(testthat)
 
 context("test-utils")
 
@@ -28,7 +29,7 @@ test_that("rnd is a very simple wrapper for round [PMT-TEST-0242]", {
 test_that("check if regular expression is valid [PMT-TEST-0243]", {
   expect_true(pmtables:::is_regex("^abc$"))
   expect_false(pmtables:::is_regex("\\textbf{foo}"))
-  expect_true(pmtables:::is_str_regex(fixed("\\textbf{foo}")))
+  expect_true(pmtables:::is_str_regex(stringr::fixed("\\textbf{foo}")))
   x <- pmtables:::as_str_regex("\\textbf{foo}")
   expected <- if (utils::packageVersion("stringr") >= "1.5.0") {
     "stringr_fixed"
@@ -91,4 +92,15 @@ test_that("add parens to vector if not there [PMT-TEST-0245]", {
 
 test_that("sig returns character when passed int [PMT-UTIL-0001]", {
   expect_is(sig(1L), "character")
+})
+
+test_that("set maxex via option", {
+  a <- sig(123455666)
+  expect_equal(a, "1.23e+08")
+  options(pmtables.maxex = Inf)
+  b <- sig(123455666)
+  expect_equal(b, "123000000")
+  options(pmtables.maxex = NULL)
+  c <- sig(123455666)
+  expect_identical(a, c)
 })


### PR DESCRIPTION
sig renders numbers as character strings with a certain number of significant digits. Big numbers can get represented in scientific notation and we can control that through the `maxex` argument. Frequently (most of the time) we don't want scientific notation and if creating this function today, I'd probably default `maxex` to some large number. 

This PR lets you control `maxex` through an option allowing users to turn off scientific notation globally in a project. 