### PR TITLE
Bug in pt_cont_long when all data summary is declined and by is passed

### DIFF
--- a/R/continuous_table.R
+++ b/R/continuous_table.R
@@ -428,13 +428,14 @@ pt_cont_long_notes <- function(note_add = NULL) {
   ans
 }
 
-
 invert_panel_by <- function(out, panel, units, all_name) {
   if(out$panel$null) return(out)
   out$data <- mutate(out$data, Variable = fct_inorder(.data[["Variable"]]))
   out$data <- mutate(out$data, !!sym(panel) := fct_inorder(!!sym(panel)))
   out$data <- arrange(out$data, .data[["Variable"]], !!sym(panel))
-  out$sumrows <- sumrow(out$data[[panel]] == all_name, it = TRUE, hline = FALSE)
+  if(all_name %in% out$data[[panel]]) {
+    out$sumrows <- sumrow(out$data[[panel]] == all_name, it = TRUE, hline = FALSE)
+  }
   out$data[["Variable"]] <- paste_units(out$data[["Variable"]], units)
   if(is_named(panel)) {
     out$data <- rename(out$data, !!sym(names(panel)) := !!sym(panel))

--- a/tests/testthat/test-cont-table.R
+++ b/tests/testthat/test-cont-table.R
@@ -40,6 +40,19 @@ test_that("invert panel and cols [PMT-TEST-0018]", {
   expect_is(ans2$sumrows, "sumrow")
 })
 
+test_that("pass by to pt_cont_long with no all data summary gh-329", {
+  table <- list(WT = "weight", ALB = "albumin", SCR = "creat")
+  ans <- pt_cont_long(
+    pmt_first,
+    col = "WT,ALB,SCR",
+    by = c(Study = "STUDYf"),
+    summarize_all = FALSE,
+    table = table
+  )
+  expect_is(ans, "pmtable")
+  expect_identical(ans$panel$col, "Variable")
+})
+
 test_that("continuous data table - wide [PMT-TEST-0019]", {
   data <- pmt_first
   ans <- pt_cont_wide(data, cols = "WT,ALB,SCR", panel = "STUDYf")


### PR DESCRIPTION
Reported by @KatherineKayMRG 

There is special handling when `by` is passed rather than `panel`. There is logic in this special handling that needs to be skipped when we decline to add an all-data summary row. 

