### PR TITLE
cont_wide_fun docs: drop stale parameter description

### DIFF
--- a/R/summary-functions.R
+++ b/R/summary-functions.R
@@ -3,7 +3,6 @@
 #' @inheritParams pt_cont_wide
 #' @param value the data to summarize
 #' @param digit_fun a function to format digits in the summaries
-#' @param id a vector of subject IDs; same length as `value`
 #' @param digits the number of digits in the summary; the current implementation
 #' passes `digits` to `digit_fun()`
 #' @param ... not used

--- a/man/cont_wide_fun.Rd
+++ b/man/cont_wide_fun.Rd
@@ -17,8 +17,6 @@ passes \code{digits} to \code{digit_fun()}}
 \item{na_fill}{value to fill with when all values in the summary are missing}
 
 \item{...}{not used}
-
-\item{id}{a vector of subject IDs; same length as \code{value}}
 }
 \value{
 A tibble with one row and one column named \code{summary}; the summary


### PR DESCRIPTION
The id parameter was removed in 0f54187 (deprecate id_col argument, 2023-01-26), part of the v0.6.0 release.