### PR TITLE
st2report and friends respect pmtables.dir output directory

### DIFF
--- a/R/preview.R
+++ b/R/preview.R
@@ -51,7 +51,8 @@ form_caption <- function(long = NULL, short = NULL, label = NULL) {
 #'
 #' @seealso [st2article()], [st2report()], [st2viewer()]
 #' @export
-st2doc <- function(text, preview = TRUE, output_dir = tempdir(), # nocov start
+st2doc <- function(text, preview = TRUE,
+                   output_dir = getOption("pmtables.dir", tempdir()), # nocov start
                    output_file = "st2doc.pdf", landscape = is_lscape(text)) {
 
   assert_that(requireNamespace("fs"))
@@ -207,7 +208,8 @@ st2viewer <- function(...) st_preview(...)
 #' @export
 st2article <- function(..., .list = NULL, ntex = 1,  #nocov start
                        stem = "view-st2article",
-                       output_dir = tempdir(), template = NULL,
+                       output_dir = getOption("pmtables.dir", tempdir()),
+                       template = NULL,
                        margin = c("2.54cm", "3cm"), caption = NULL,
                        dry_run = FALSE, stdout = FALSE, show_pdf = TRUE) {
   tables <- c(list(...),.list)

--- a/man/st2article.Rd
+++ b/man/st2article.Rd
@@ -10,7 +10,7 @@ st2article(
   .list = NULL,
   ntex = 1,
   stem = "view-st2article",
-  output_dir = tempdir(),
+  output_dir = getOption("pmtables.dir", tempdir()),
   template = NULL,
   margin = c("2.54cm", "3cm"),
   caption = NULL,

--- a/man/st2doc.Rd
+++ b/man/st2doc.Rd
@@ -7,7 +7,7 @@
 st2doc(
   text,
   preview = TRUE,
-  output_dir = tempdir(),
+  output_dir = getOption("pmtables.dir", tempdir()),
   output_file = "st2doc.pdf",
   landscape = is_lscape(text)
 )

--- a/tests/testthat/test-preview.R
+++ b/tests/testthat/test-preview.R
@@ -63,9 +63,20 @@ test_that("error to call st_asis on non-stable object [PMT-TEST-0175]", {
     msg = "x does not inherit from class stable"
   )
 })
-          
+
 test_that("st2report - list names are escaped [PMT-TEST-0176]", {
   l <- list(a = stable(stdata()), `a_b` = stable(stdata()))
   a <- st2report(l, dry_run = TRUE)
   expect_equal(names(a), c("a", "a\\_b"))
+})
+
+test_that("st2report respects pmtables.dir option", {
+  tab <- stable(stdata())
+  dir <- tempfile()
+  unlink(dir, recursive = TRUE)
+  dir.create(dir)
+  options(pmtables.dir = dir)
+  x <- st2report(tab, show_pdf = FALSE, stem = "st2report-test-pmtables-dir")
+  expect_true(file.exists(file.path(dir, "st2report-test-pmtables-dir.pdf")))
+  options(pmtables.dir = NULL)
 })


### PR DESCRIPTION
# Summary

This PR updates the `output_dir` argument to a set of pdf preview functions to look at  the`pmtables.dir` option first before sending to `tempdir()`.