### PR TITLE
Release/0.7.0

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -30,7 +30,6 @@ inst/test_data\.R
 Makefile
 ^README\.Rmd$
 ^README\.md$
-^NEWS\.md$
 inst/covr
 ^\.github$
 pmtables\.Rcheck

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pmtables
 Type: Package
 Title: Tables for Pharmacometrics
-Version: 0.6.0.9002
+Version: 0.7.0
 Authors@R: 
     c(
     person(given = "Kyle",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,7 @@ Suggests: testthat, yaml, fs, texPreview, magick, pdftools
 Encoding: UTF-8
 Language: en-US
 LazyData: true
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
 Collate: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,6 +29,8 @@ Maintainer: Kyle Baron <kyleb@metrumrg.com>
 Description: Summarize data sets and create publication-quality tables for 
     inclusion in 'tex' documents.
 License: GPL (>=2)
+URL: https://metrumresearchgroup.github.io/pmtables, https://github.com/metrumresearchgroup/pmtables
+BugReports: https://github.com/metrumresearchgroup/pmtables/issues
 Imports: purrr (>= 1.0.0), dplyr (>= 1.0.0), forcats, tidyr, rlang, glue, tibble,
     assertthat, tidyselect, stringr, knitr, rmarkdown, lifecycle
 Depends: R (>= 3.5.0)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,23 @@
-# pmtables (development version)
+# pmtables 0.7.0
+
+- New functionality to create table notes from glossary files (#326). 
+  - `read_glossary()` reads from `.tex` or `.yaml` formatted files, returning a
+    glossary object
+  - `select_glossary()` selects specific entries from a glossary object
+  - `as_glossary()` creates a glossary object on the fly or from a list
+  - `glossary_notes()` creates notes from a glossary object, a list, or the 
+    name of a glossary file
+  - `st_notes_glo()` creates and and attaches notes to a table in a pipeline
+- `stable_save_image()` added to create an image from a table and save to a 
+  specific location; this builds on `[`st_aspdf()`]` and `st_aspng()` and 
+  adding convenient syntax and options (#333). 
+- The `maxex` argument to `sig()` can now be set through the `pmtables.maxex` 
+  option (#328). 
+
+## Bugs Fixed
+
+- Fixed a bug in `pt_cat_long()` when the `by` argument is used with no all 
+  data summary (#330).
 
 # pmtables 0.6.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@
     name of a glossary file
   - `st_notes_glo()` creates and and attaches notes to a table in a pipeline
 - `stable_save_image()` added to create an image from a table and save to a 
-  specific location; this builds on `[`st_aspdf()`]` and `st_aspng()` and 
+  specific location; this builds on `st_aspdf()` and `st_aspng()` and 
   adding convenient syntax and options (#333). 
 - The `maxex` argument to `sig()` can now be set through the `pmtables.maxex` 
   option (#328). 

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,8 +9,8 @@
     name of a glossary file
   - `st_notes_glo()` creates and and attaches notes to a table in a pipeline
 - `stable_save_image()` added to create an image from a table and save to a 
-  specific location; this builds on `st_aspdf()` and `st_aspng()` and 
-  adding convenient syntax and options (#333). 
+  specific location; this builds on `st_aspdf()` and `st_aspng()`, adding 
+  convenient syntax and options (#333). 
 - The `maxex` argument to `sig()` can now be set through the `pmtables.maxex` 
   option (#328). 
 

--- a/R/AAAA.R
+++ b/R/AAAA.R
@@ -163,6 +163,15 @@ NULL
 #' `context = "rmd"` option. See [st2article()] for instructions on
 #' how to view a complete working `latex` example.
 #'
+#' @section Glossaries:
+#' - Use [read_glossary()] to read abbreviations and definitions from a
+#'   file in `.tex` or `.yaml` format.
+#' - Use [as_glossary()] to create a glossary object in R.
+#' - Use [select_glossary()] to select specific labels from a glossary object.
+#' - Use [glossary_notes()] to create table notes from a glossary object.
+#' - Use [st_notes_glo()] to create glossary notes from a glossary object
+#'   and attach to a table in a pipeline.
+#'
 #' @section Data sets:
 #' - [analysis1] - a NMTRAN-style data set; the basis for most other
 #'   example data sets

--- a/README.Rmd
+++ b/README.Rmd
@@ -43,7 +43,7 @@ You can install the development version from [GitHub](https://github.com/) with:
 
 ``` r
 # install.packages("devtools")
-devtools::install_github("metrumresearchgroup/pmplots")
+devtools::install_github("metrumresearchgroup/pmtables")
 ```
 
 # Documentation 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can install the development version from
 
 ``` r
 # install.packages("devtools")
-devtools::install_github("metrumresearchgroup/pmplots")
+devtools::install_github("metrumresearchgroup/pmtables")
 ```
 
 # Documentation

--- a/man/pmtables.Rd
+++ b/man/pmtables.Rd
@@ -2,6 +2,7 @@
 % Please edit documentation in R/AAAA.R
 \docType{package}
 \name{pmtables}
+\alias{pmtables-package}
 \alias{pmtables}
 \title{pmtables: Tables for Pharmacometrics.}
 \description{
@@ -191,3 +192,24 @@ each individual
 }
 }
 
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://metrumresearchgroup.github.io/pmtables}
+  \item \url{https://github.com/metrumresearchgroup/pmtables}
+  \item Report bugs at \url{https://github.com/metrumresearchgroup/pmtables/issues}
+}
+
+}
+\author{
+\strong{Maintainer}: Kyle Baron \email{kyleb@metrumrg.com}
+
+Other contributors:
+\itemize{
+  \item Anna-Christina Nevison \email{annan@metrumrg.com} [contributor]
+  \item Katherine Kay \email{katherinek@metrumrg.com} [contributor]
+  \item Devin Pastoor \email{devin.pastoor@gmail.com} [contributor]
+  \item Kyle Barrett \email{barrettk@metrumrg.com} [contributor]
+}
+
+}

--- a/man/pmtables.Rd
+++ b/man/pmtables.Rd
@@ -165,6 +165,19 @@ fence looks like by running \code{st_latex("abc")}. Asserting that the code is
 how to view a complete working \code{latex} example.
 }
 
+\section{Glossaries}{
+
+\itemize{
+\item Use \code{\link[=read_glossary]{read_glossary()}} to read abbreviations and definitions from a
+file in \code{.tex} or \code{.yaml} format.
+\item Use \code{\link[=as_glossary]{as_glossary()}} to create a glossary object in R.
+\item Use \code{\link[=select_glossary]{select_glossary()}} to select specific labels from a glossary object.
+\item Use \code{\link[=glossary_notes]{glossary_notes()}} to create table notes from a glossary object.
+\item Use \code{\link[=st_notes_glo]{st_notes_glo()}} to create glossary notes from a glossary object
+and attach to a table in a pipeline.
+}
+}
+
 \section{Data sets}{
 
 \itemize{


### PR DESCRIPTION
# pmtables 0.7.0

- New functionality to create table notes from glossary files (#326). 
  - `read_glossary()` reads from `.tex` or `.yaml` formatted files, returning a
    glossary object
  - `select_glossary()` selects specific entries from a glossary object
  - `as_glossary()` creates a glossary object on the fly or from a list
  - `glossary_notes()` creates notes from a glossary object, a list, or the 
    name of a glossary file
  - `st_notes_glo()` creates and and attaches notes to a table in a pipeline
- `stable_save_image()` added to create an image from a table and save to a 
  specific location; this builds on `[`st_aspdf()`]` and `st_aspng()` and 
  adding convenient syntax and options (#333). 
- The `maxex` argument to `sig()` can now be set through the `pmtables.maxex` 
  option (#328). 
