### PR TITLE
Only pass environment into glue

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,7 @@ Suggests: testthat, yaml, texPreview, magick, pdftools, withr
 Encoding: UTF-8
 Language: en-US
 LazyData: true
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
 Collate: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,6 @@ Language: en-US
 LazyData: true
 RoxygenNote: 7.3.2
 Roxygen: list(markdown = TRUE)
-VignetteBuilder: knitr
 Collate: 
     'class-new_names.R'
     'class-digits.R'

--- a/R/AAAA.R
+++ b/R/AAAA.R
@@ -198,10 +198,8 @@ find_cached_root <- function() {
 #
 #'
 #' @md
-#' @docType package
 #' @name pmtables
-NULL
-
+"_PACKAGE"
 
 #' Load an example data set
 #'

--- a/R/preview-standalone.R
+++ b/R/preview-standalone.R
@@ -98,15 +98,14 @@ st_to_standalone <- function(text, stem, dir,
     vwidth <- ""
   }
 
-  env <- list(
-    border = border,
-    texfile = texfile,
-    font = fonts[[font]],
-    textw_tex = as.character(textw_tex),
-    rule = rule,
-    vwidth = vwidth,
-    ltversion = paste0("[=v", ltversion, "]%")
-  )
+  env <- new.env()
+  env$border <- border
+  env$texfile <- texfile
+  env$font <- fonts[[font]]
+  env$textw_tex <- as.character(textw_tex)
+  env$rule <- rule
+  env$vwidth <- vwidth
+  env$ltversion <- paste0("[=v", ltversion, "]%")
 
   temp_text <- mgluet(temp_text, .envir = env)
   build_file <- basename(temp_file)

--- a/R/preview.R
+++ b/R/preview.R
@@ -248,7 +248,7 @@ st2article <- function(..., .list = NULL, ntex = 1,  #nocov start
 
   temp <- readLines(template)
 
-  env <- list()
+  env <- new.env()
   env$list_of_tables <- c("\\listoftables", "\\clearpage")
   env$input_file <- st2article_input
   env$hmargin <- margin[1]

--- a/R/table-utils.R
+++ b/R/table-utils.R
@@ -113,7 +113,7 @@ require_col <- function(data,col,context=NULL) {
 gluet <- function(x, .envir = parent.frame(), ...) {
   x <- force(x)
   if(!is.environment(.envir)) {
-    abort("pmtables error: cannot glue into .envir that is not environment")
+    abort("pmtables error: cannot `glue()` - .envir is not an environment.")
   }
   glue(x,.open = "<", .close = ">", .envir = .envir)
 }

--- a/R/table-utils.R
+++ b/R/table-utils.R
@@ -112,6 +112,9 @@ require_col <- function(data,col,context=NULL) {
 
 gluet <- function(x, .envir = parent.frame(), ...) {
   x <- force(x)
+  if(!is.environment(.envir)) {
+    abort("pmtables error: cannot glue into .envir that is not environment")
+  }
   glue(x,.open = "<", .close = ">", .envir = .envir)
 }
 

--- a/man/pmtables.Rd
+++ b/man/pmtables.Rd
@@ -2,6 +2,7 @@
 % Please edit documentation in R/AAAA.R
 \docType{package}
 \name{pmtables}
+\alias{pmtables-package}
 \alias{pmtables}
 \title{pmtables: Tables for Pharmacometrics.}
 \description{
@@ -191,3 +192,24 @@ each individual
 }
 }
 
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://metrumresearchgroup.github.io/pmtables}
+  \item \url{https://github.com/metrumresearchgroup/pmtables}
+  \item Report bugs at \url{https://github.com/metrumresearchgroup/pmtables/issues}
+}
+
+}
+\author{
+\strong{Maintainer}: Kyle Baron \email{kyleb@metrumrg.com}
+
+Other contributors:
+\itemize{
+  \item Anna-Christina Nevison \email{annan@metrumrg.com} [contributor]
+  \item Katherine Kay \email{katherinek@metrumrg.com} [contributor]
+  \item Devin Pastoor \email{devin.pastoor@gmail.com} [contributor]
+  \item Kyle Barrett \email{barrettk@metrumrg.com} [contributor]
+}
+
+}

--- a/tests/testthat/test-table-utils.R
+++ b/tests/testthat/test-table-utils.R
@@ -278,3 +278,12 @@ test_that("table-utils paste units [PMT-TEST-0239]", {
     c("B mg", "E", "D kg", "C pounds", "A")
   )
 })
+
+test_that("error is generated when calling gluet with non-environment", {
+  x <- list(a = 1, b = 2, c = 3)
+  what <- "<b><a><c>"
+  expect_error(pmtables:::gluet(what, .envir = x), "pmtables error:")
+  env <- as.environment(x)
+  ans <- pmtables:::gluet(what, .envir = env)
+  expect_identical(unclass(ans), "213")
+})


### PR DESCRIPTION
# Summary 

glue 1.8.0 was recently released and is now insisting that `.envir` argument to `glue()` is really an environment. pmtables was sometimes passing a list. This was always happening through this `gluet()` helper I wrote to use `<>` rather than `{}` to glue stuff into latex code.  This has been fixed now. Also issuing an informative error message in case `gluet()` ever gets non-environment. And added a regression test specifically for `gluet()`.  

I also noticed some minor documentation issues that came up, presumably with new roxygen2 version; these also have been addressed in this PR as well. 

@barrettk @graceannobrien 