### PR TITLE
ci: update OS and check more R versions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,13 +17,13 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             r: 3.6.3
             # For a texPreview that's still compatible with R < 4.0
-            rspm: 'https://packagemanager.posit.co/cran/__linux__/focal/2022-03-25'
-          - os: ubuntu-20.04
+            rspm: 'https://packagemanager.posit.co/cran/__linux__/jammy/2022-03-25'
+          - os: ubuntu-22.04
             r: 4.0.5
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             r: 4.1.3
           - os: ubuntu-latest
             r: release

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,12 +19,18 @@ jobs:
         config:
           - os: ubuntu-22.04
             r: 3.6.3
-            # For a texPreview that's still compatible with R < 4.0
-            rspm: 'https://packagemanager.posit.co/cran/__linux__/jammy/2022-03-25'
+            # details v0.4.0 requires R >= 4.2.0.
+            details_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2023-12-05/src/contrib/details_0.3.0.tar.gz'
+            # texPreview v2.0.0 requires R >= 4.0.0.
+            texPreview_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2022-03-21/src/contrib/texPreview_1.5.tar.gz'
           - os: ubuntu-22.04
             r: 4.0.5
+            # details v0.4.0 requires R >= 4.2.0.
+            details_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2023-12-05/src/contrib/details_0.3.0.tar.gz'
           - os: ubuntu-22.04
             r: 4.1.3
+            # details v0.4.0 requires R >= 4.2.0.
+            details_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2023-12-05/src/contrib/details_0.3.0.tar.gz'
           - os: ubuntu-22.04
             r: 4.2.3
           - os: ubuntu-22.04
@@ -39,14 +45,14 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
           use-public-rspm: true
-        env:
-          RSPM: ${{ matrix.config.rspm }}
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |
             any::pkgdown
             any::rcmdcheck
-          upgrade: ${{ matrix.config.r == '3.6.3' && 'FALSE' || 'TRUE' }}
+            ${{ matrix.config.details_pkg }}
+            ${{ matrix.config.texPreview_pkg }}
+          upgrade: ${{ (matrix.config.r == '3.6.3' || matrix.config.r == '4.0.5' || matrix.config.r == '4.1.3') && 'FALSE' || 'TRUE' }}
       - name: Install other system dependencies
         shell: bash
         run: sudo apt-get install dvipng texlive-latex-base texlive-fonts-extra

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,6 +25,10 @@ jobs:
             r: 4.0.5
           - os: ubuntu-22.04
             r: 4.1.3
+          - os: ubuntu-22.04
+            r: 4.2.3
+          - os: ubuntu-22.04
+            r: 4.3.1
           - os: ubuntu-latest
             r: release
     env:


### PR DESCRIPTION
 * update to `ubuntu-22.04` to prepare for the retirement of `ubuntu-20.04`.

 * add check jobs for R 4.2.3 and R 4.3.1 to cover the latest R versions on Metworx
 
 * resolve failure due to latest `details` package requiring R 4.2.0 
