### PR TITLE
README.md: regenerate to fix logo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-# pmtables <img align="right" src = "logo.png" width="135px">
+# pmtables <img align="right" src = "man/figures/logo.png" width="135px">
 
 <!-- badges: start -->
 <!-- badges: end -->
@@ -52,17 +52,17 @@ We maintain a pmtables book
 
 # Examples in working docs
 
--   General table examples:
-    [inst/demo-table.pdf](https://github.com/metrumresearchgroup/pmtables/blob/main/inst/demo-table.pdf)
+- General table examples:
+  [inst/demo-table.pdf](https://github.com/metrumresearchgroup/pmtables/blob/main/inst/demo-table.pdf)
 
--   General tables - pipe interface:
-    [inst/demo-pipe.pdf](https://github.com/metrumresearchgroup/pmtables/blob/main/inst/demo-pipe.pdf)
+- General tables - pipe interface:
+  [inst/demo-pipe.pdf](https://github.com/metrumresearchgroup/pmtables/blob/main/inst/demo-pipe.pdf)
 
--   Standard table examples:
-    [inst/demo-pmtable.pdf](https://github.com/metrumresearchgroup/pmtables/blob/main/inst/demo-pmtable.pdf)
+- Standard table examples:
+  [inst/demo-pmtable.pdf](https://github.com/metrumresearchgroup/pmtables/blob/main/inst/demo-pmtable.pdf)
 
--   Long table examples:
-    [inst/demo-longtable.pdf](https://github.com/metrumresearchgroup/pmtables/blob/main/inst/demo-longtable.pdf)
+- Long table examples:
+  [inst/demo-longtable.pdf](https://github.com/metrumresearchgroup/pmtables/blob/main/inst/demo-longtable.pdf)
 
--   What is sanitized:
-    [inst/demo-sanitize.pdf](https://github.com/metrumresearchgroup/pmtables/blob/main/inst/demo-sanitize.pdf)
+- What is sanitized:
+  [inst/demo-sanitize.pdf](https://github.com/metrumresearchgroup/pmtables/blob/main/inst/demo-sanitize.pdf)


### PR DESCRIPTION
In cfa2baf (man/figures: rename logo, 2024-12-18), I updated the logo path in README.Rmd but not in README.md (obviously doing some bold manual editing of a generated file :x).

Fix the issue by regenerating README.md with

    rmarkdown::render("README.Rmd")

(This brings along whitespace noise that's presumably the result of updated versions.)

---

**Before**

![20250212T164854](https://github.com/user-attachments/assets/f7a822e9-31b5-496f-950a-0a568ff862fc)

**After**

![20250212T164837](https://github.com/user-attachments/assets/315fc31b-c7de-4434-932e-51a7e7443210)

