### PR TITLE
Refactor pt_demographics

### DIFF
--- a/R/demographics-table.R
+++ b/R/demographics-table.R
@@ -293,7 +293,7 @@ pt_demographics <- function(data, cols_cont, cols_cat,
   }
   # Drop rows where all are missing
   drop_miss <- isTRUE(drop_miss)
-  stat_col <- which(names(table_data)=="Statistic")
+  stat_col <- which(names(table_data)==stat_name)
   cols_to_check <- seq(3, ncol(table_data))
   check_missing_row <- function(row) {
     row[stat_col] == "Missing" && all(row[cols_to_check]=="0")

--- a/R/demographics-table.R
+++ b/R/demographics-table.R
@@ -289,7 +289,13 @@ pt_demographics <- function(data, cols_cont, cols_cat,
   }
   # add units
   units <- validate_units(units, data)
+  units <- units[vapply(units, is.character, TRUE)]
+  units <- units[vapply(units, nchar, 1L) > 0]
   if(!is.null(units)) {
+    cat_unit_set <- setdiff(cols_cat, names(units))
+    if(length(cat_unit_set)) {
+      units[cat_unit_set] <- rep("n (%)", length(cat_unit_set))
+    }
     all_cols <- c(cols_cont, cols_cat)
     has_unit <- match(names(units), all_cols)
     nw <- names(all_cols)

--- a/R/demographics-table.R
+++ b/R/demographics-table.R
@@ -115,8 +115,9 @@ dem_cont_fun <- function(value = seq(1,5), name = "",  ..., fmt = sig,
 #' covariate names; otherwise, the covariate names will appear as the left-most
 #' column with non-repeating names cleared and separated with `hline` (see
 #' examples).
-#' @param drop_miss the `Missing` statistic rows will be dropped _if_ there are
-#' no missing values; set this to `FALSE` to retain these rows.
+#' @param drop_miss rows where the `Statistic` column is `Missing` will be
+#' dropped _if_ there are no missing values; set this to `FALSE` to retain
+#' these rows.
 #'
 #' @details
 #' When a continuous data summary function (`fun`) is passed, the user should
@@ -303,13 +304,7 @@ pt_demographics <- function(data, cols_cont, cols_cat,
   }
   # add units
   units <- validate_units(units, data)
-  # units <- units[vapply(units, is.character, TRUE)]
-  # units <- units[vapply(units, nchar, 1L) > 0]
   if(!is.null(units)) {
-    # cat_unit_set <- setdiff(cols_cat, names(units))
-    # if(length(cat_unit_set)) {
-    #   units[cat_unit_set] <- rep("(n (%))", length(cat_unit_set))
-    # }
     all_cols <- c(cols_cont, cols_cat)
     has_unit <- match(names(units), all_cols)
     nw <- names(all_cols)

--- a/R/demographics-table.R
+++ b/R/demographics-table.R
@@ -65,6 +65,7 @@ dem_cont_fun <- function(value = seq(1,5), name = "",  ..., fmt = sig,
                          digits = 3, maxex = 5) {
   tibble(
     `Mean (SD)` = .mean_sd(value, fmt = fmt, digits = digits, maxex = maxex),
+    `Median` = .median(value, fmt = fmt, digits = digits, maxex = maxex),
     `Min / Max` = .min_max(value, fmt = fmt, digits = digits, maxex = maxex),
     `Missing` = as.character(sum(is.na(value)), digits = digits, maxex = maxex)
   )
@@ -76,6 +77,10 @@ dem_cont_fun <- function(value = seq(1,5), name = "",  ..., fmt = sig,
   Mean <- fmt(mean(value, na.rm = TRUE), ...)
   Sd <- fmt(sd(value, na.rm = TRUE), ...)
   paste0(Mean, " (", Sd, ")")
+}
+.median <- function(value, fmt = sig, ...) {
+  Median <- fmt(median(value, na.rm = TRUE), ...)
+  Median
 }
 
 #' Summarize continuous and categorical data in long format

--- a/R/demographics-table.R
+++ b/R/demographics-table.R
@@ -292,15 +292,11 @@ pt_demographics <- function(data, cols_cont, cols_cat,
     table_data <- rename(table_data, !!sym(all_name) := "value")
   }
   # Drop rows where all are missing
-  drop_miss <- isTRUE(drop_miss)
-  stat_col <- which(names(table_data)==stat_name)
-  cols_to_check <- seq(3, ncol(table_data))
-  check_missing_row <- function(row) {
-    row[stat_col] == "Missing" && all(row[cols_to_check]=="0")
-  }
-  if(isTRUE(drop_miss) && length(stat_col)==1) {
-    drop_these_rows <- apply(table_data, MARGIN = 1, FUN = check_missing_row)
-    table_data <- table_data[!drop_these_rows,]
+  if (isTRUE(drop_miss)) {
+    val_cols <- setdiff(names(table_data), c("name", stat_name))
+    rows_to_keep <- table_data[, stat_name] != "Missing" |
+      rowSums(table_data[, val_cols] != "0") > 0
+    table_data <- table_data[rows_to_keep, ]
   }
   # add units
   units <- validate_units(units, data)

--- a/man/pt_demographics.Rd
+++ b/man/pt_demographics.Rd
@@ -18,7 +18,8 @@ pt_demographics(
   fun = dem_cont_fun,
   notes = pt_demographics_notes(),
   paneled = TRUE,
-  denom = c("group", "total")
+  denom = c("group", "total"),
+  drop_miss = TRUE
 )
 }
 \arguments{
@@ -67,6 +68,10 @@ examples).}
 \code{group} uses the total number in the chunk being summarized; \code{total} uses
 the total number in the data set; historically, \code{group} has been used as the
 default.}
+
+\item{drop_miss}{rows where the \code{Statistic} column is \code{Missing} will be
+dropped \emph{if} there are no missing values; set this to \code{FALSE} to retain
+these rows.}
 }
 \value{
 An object of class \code{pmtable}.

--- a/tests/testthat/test-demographics-table.R
+++ b/tests/testthat/test-demographics-table.R
@@ -191,8 +191,9 @@ test_that("demographics data summary - spot check values [PMT-TEST-0052]", {
     span = c("STUDYf"),
     stat_name = "Statistic"
   )
+  # Indices reflect dropped Missing statistics
   expect_true(out$data$`12-DEMO-001`[4] == ab1)
-  expect_true(out$data$`12-DEMO-002`[2] == ab2)
+  expect_true(out$data$`12-DEMO-002`[3] == ab2)
 })
 
 test_that("statistic column gets renamed [PMT-TEST-0053]", {
@@ -233,10 +234,11 @@ test_that("set width of Statistic column [PMT-TEST-0057]", {
 test_that("table argument is implemented [PMT-TEST-0058]", {
   tab <- list(WT = "Weight (kg)", SCR = "Creat", ASIANf = "Asian")
   out <- pt_demographics(pmt_first, "WT,AGE,SCR", cat, table = tab)
+  # Indices account for removal of Missing stat where appropriate
   expect_equal(out$data$name[1], "Weight (kg)")
-  expect_equal(out$data$name[4], "AGE")
-  expect_equal(out$data$name[7], "Creat")
-  expect_equal(out$data$name[12], "Asian")
+  expect_equal(out$data$name[5], "AGE")
+  expect_equal(out$data$name[8], "Creat")
+  expect_equal(out$data$name[13], "Asian")
 })
 
 test_that("demographics table has group argument [PMT-TEST-0059]", {
@@ -273,4 +275,23 @@ test_that("demographics table has group argument [PMT-TEST-0059]", {
   test2 <- select(filter(tab2a, name != "WT"), -1, -2)
   ref2 <- select(tab2b, -1, -2)
   expect_identical(test2, ref2)
+})
+
+test_that("Median is included in default statistics", {
+  out <- pt_demographics(pmt_first, cont, cat)
+  n <- sum(out$data$Statistic=="Median")
+  expect_equal(n, length(pmtables:::cvec_cs(cont)))
+})
+
+test_that("Control how Missing stat is handled", {
+  cont2 <- c("AGE", "BMI", "HT", "ALT", "AST")
+  out <- pt_demographics(pmt_first, cont2, cat)
+  expect_equal(sum(out$data$Statistic=="Missing"), 0)
+
+  cont3 <- c(cont2, "WT", "CRCL")
+  out <- pt_demographics(pmt_first, cont3, cat)
+  expect_equal(sum(out$data$Statistic=="Missing"), 2)
+
+  out <- pt_demographics(pmt_first, cont3, cat, drop_miss = FALSE)
+  expect_equal(sum(out$data$Statistic=="Missing"), length(cont3))
 })


### PR DESCRIPTION
1. Include median by default
2. When `Statistic` is "Missing" and all summary values are `0`, we drop those rows
3. Add argument `drop_miss` set to `TRUE` by default; set to `FALSE` to skip the check for Missing stat
4. For now, not going to add any unit to categorical summaries beyond what comes through in the unit list



``` r
library(dplyr)
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
library(pmtables)

pt_demographics(
  pmt_first,
  cols_cont = c("WT", "AGE"),
  cols_cat = c("ASIANf", "FORMf"),
  unit = list(WT = "(kg)", AGE = "(years)"),
  table = list(ASIANf = "Asian", WT = "Weight", AGE = "Age", FORMf = "Formulation"),
  span = c(Study = "STUDYf")
) %>% st_as_image()
```

<img src="https://i.imgur.com/gRabhHO.png" width="1897" />

<sup>Created on 2025-09-06 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>