### PR TITLE
Minor tweak to Rd documentation - link to summarize_cat_chunk

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,7 @@ Suggests: testthat, yaml, texPreview, magick, pdftools, withr
 Encoding: UTF-8
 Language: en-US
 LazyData: true
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Roxygen: list(markdown = TRUE)
 Collate: 
     'class-new_names.R'

--- a/R/summarize-cat-chunk.R
+++ b/R/summarize-cat-chunk.R
@@ -24,7 +24,7 @@ summarize_cat_chunk <- function(data, cols, N, denom = "group") {
 #'
 #' @param name the column name to summarize.
 #' @param data the data frame to summarize from.
-#' @param D the denominator to use; this was set in [summarize_cat_chunk()].
+#' @param D the denominator to use; this was set in `summarize_cat_chunk()`.
 #' @param Nchunk the number of records in the chunk being summarized.
 #' @return
 #' - `N` is the number of records in the chunk


### PR DESCRIPTION
Roxygen raised this issue. Solution was to remove the linking. 


```r
✖ summarize-cat-chunk.R:27: @param Could not resolve link to topic "summarize_cat_chunk" in the
  dependencies or base packages.
ℹ If you haven't documented "summarize_cat_chunk" yet, or just changed its name, this is normal.
  Once "summarize_cat_chunk" is documented, this warning goes away.
ℹ Make sure that the name of the topic is spelled correctly.
ℹ Always list the linked package as a dependency.
ℹ Alternatively, you can fully qualify the link with a package name.
```