### PR TITLE
ci: use date-pinned RSPM for R <4.2 jobs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,30 +19,17 @@ jobs:
         config:
           - os: ubuntu-22.04
             r: 3.6.3
-            # details v0.4.0 requires R >= 4.2.0.
-            details_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2023-12-05/src/contrib/details_0.3.0.tar.gz'
             # texPreview v2.0.0 requires R >= 4.0.0.
             texPreview_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2022-03-21/src/contrib/texPreview_1.5.tar.gz'
+            rspm: 'https://packagemanager.posit.co/cran/__linux__/jammy/2023-12-05'
             pinned: true
           - os: ubuntu-22.04
             r: 4.0.5
-            # details v0.4.0 requires R >= 4.2.0.
-            details_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2023-12-05/src/contrib/details_0.3.0.tar.gz'
-            # httr2 v1.2.0 requires at least R 4.1.
-            httr2_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2025-06-16/src/contrib/httr2_1.1.2.tar.gz'
-            # magick v2.8.6 requires R >= 4.1.0.
-            magick_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2025-02-26/src/contrib/magick_2.8.5.tar.gz'
-            # paws.common v0.8.5 requires at least R 4.1.
-            paws_common_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2025-06-16/src/contrib/paws.common_0.8.4.tar.gz'
-            # purrr v1.1.0 requires at least R 4.1.
-            purrr_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2025-06-16/src/contrib/purrr_1.0.4.tar.gz'
-            # scales v1.4.0 requires R >= 4.1.0.
-            scales_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2025-04-23/src/contrib/scales_1.3.0.tar.gz'
             pinned: true
+            rspm: 'https://packagemanager.posit.co/cran/__linux__/jammy/2023-12-05'
           - os: ubuntu-22.04
             r: 4.1.3
-            # details v0.4.0 requires R >= 4.2.0.
-            details_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2023-12-05/src/contrib/details_0.3.0.tar.gz'
+            rspm: 'https://packagemanager.posit.co/cran/__linux__/jammy/2023-12-05'
             pinned: true
           - os: ubuntu-22.04
             r: 4.2.3
@@ -58,17 +45,13 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
           use-public-rspm: true
+        env:
+          RSPM: ${{ matrix.config.rspm }}
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |
             any::pkgdown
             any::rcmdcheck
-            ${{ matrix.config.details_pkg }}
-            ${{ matrix.config.httr2_pkg }}
-            ${{ matrix.config.magick_pkg }}
-            ${{ matrix.config.paws_common_pkg }}
-            ${{ matrix.config.purrr_pkg }}
-            ${{ matrix.config.scales_pkg }}
             ${{ matrix.config.texPreview_pkg }}
           upgrade: ${{ matrix.config.pinned && 'FALSE' || 'TRUE' }}
       - name: Install other system dependencies


### PR DESCRIPTION
The R 4.0 job is currently failing due to a package update causing a version incompatibility.  To resolve that (and reduce the need to fix future incompatibilities as more packages drop support for older R versions), this switches to using a date-pinned repo for jobs using R 4.2 or older.