### PR TITLE
Address missing values in the by column under pt_data_inventory

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pmtables
 Type: Package
 Title: Tables for Pharmacometrics
-Version: 0.10.0
+Version: 0.10.0.9000
 Authors@R: 
     c(
     person(given = "Kyle",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # pmtables (development version)
 
+## Bugs Fixed
+
+- Fixed a bug in `pt_data_inventory()` where missing values in the `by` column
+  resulted in the missing value summary getting labeled as a summary row; 
+  this fix replaces missing values with character `"NA"` as the table is 
+  built (#373).
+
 # pmtables 0.10.0
 
 - Brackets in table body or table notes are now sanitized or masked by default to

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,9 +3,10 @@
 ## Bugs Fixed
 
 - Fixed a bug in `pt_data_inventory()` where missing values in the `by` column
-  resulted in the missing value summary getting labeled as a summary row; 
-  this fix replaces missing values with character `"NA"` as the table is 
-  built (#373).
+  resulted in the missing value summary row getting labeled as an "All data" 
+  summary row; this fix replaces missing values with the character string 
+  `"NA"` as the table is built and "All data" summary rows are now properly
+  labeled (#373).
 
 # pmtables 0.10.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# pmtables (development version)
+
 # pmtables 0.10.0
 
 - Brackets in table body or table notes are now sanitized or masked by default to

--- a/R/data_inventory_table.R
+++ b/R/data_inventory_table.R
@@ -172,6 +172,7 @@ data_inventory_data <- function(data, by, panel = by, all_name = "all",
         PBQL = "---"
       )
     }
+    ans <- mutate(ans, !!sym(by) := replace_na(!!sym(by), "NA"))
     ans <- bind_rows(ans,tot)
   }
 

--- a/tests/testthat/test-inventory-table.R
+++ b/tests/testthat/test-inventory-table.R
@@ -306,3 +306,14 @@ test_that("Long inventory table - errors", {
     fixed = TRUE
   )
 })
+
+test_that("Missing value in by column is handled properly gh-372", {
+  data <- pmt_obs
+  data$ASIAN[c(1,100,500,800,2000)] <- NA_character_
+  a <- pt_data_inventory(data, by = "ASIAN")$data
+  expect_equal(sum(is.na(data$ASIAN)), 5)
+  expect_equal(nrow(a), 4)
+  expect_equal(a$Number.OBS[3], 5)
+  expect_identical(a$ASIAN[1:3], c("Asian", "non-Asian", "NA"))
+  expect_match(a$ASIAN[4], "All data")
+})


### PR DESCRIPTION
See #372 

The fix will be to call `replace_na()` on the `by` column prior to binding on the "total" row. 

TODO: 

- [x] Add test