### PR TITLE
Ungroup incoming data in pt_cont_wide and pt_cont_long

### DIFF
--- a/R/continuous_table.R
+++ b/R/continuous_table.R
@@ -149,6 +149,9 @@ pt_cont_wide <- function(data, cols,
     deprecate_warn("0.5.3", "pt_cont_wide(id_col)")
   }
 
+  assert_that(is.data.frame(data))
+  data <- as.data.frame(data)
+
   has_panel <- !missing(panel)
   panel_data <- as.panel(panel)
   panel <- panel_data$col
@@ -161,6 +164,7 @@ pt_cont_wide <- function(data, cols,
   cols <- new_names(cols,table)
   by <- new_names(by,table)
   panel <- new_names(panel,table)
+
 
   data <- data_total_col(data, all_name = all_name)
 
@@ -333,6 +337,10 @@ pt_cont_long <- function(data,
 
   by <- panel
   summarize_all <- summarize_all & by != ".total"
+
+  assert_that(is.data.frame(data))
+  data <- as.data.frame(data)
+
   data <- data_total_col(data)
 
   cols <- new_names(cols,table)

--- a/R/continuous_table.R
+++ b/R/continuous_table.R
@@ -149,9 +149,6 @@ pt_cont_wide <- function(data, cols,
     deprecate_warn("0.5.3", "pt_cont_wide(id_col)")
   }
 
-  assert_that(is.data.frame(data))
-  data <- as.data.frame(data)
-
   has_panel <- !missing(panel)
   panel_data <- as.panel(panel)
   panel <- panel_data$col
@@ -165,6 +162,8 @@ pt_cont_wide <- function(data, cols,
   by <- new_names(by,table)
   panel <- new_names(panel,table)
 
+  assert_that(is.data.frame(data))
+  data <- as.data.frame(data)
 
   data <- data_total_col(data, all_name = all_name)
 

--- a/tests/testthat/test-cont-table.R
+++ b/tests/testthat/test-cont-table.R
@@ -149,10 +149,10 @@ test_that("pt_cont_x run with no ID column", {
 
 test_that("pt_cont_long ungroups data", {
   data <- dplyr::group_by(pmt_first, SEXf, SEQf)
-  expect_silent(pt_cont_long(data, cols = "WT, CRCL" ,by = "RF"))
+  expect_silent(pt_cont_long(data, cols = "WT,CRCL", by = "RF"))
 })
 
 test_that("pt_cont_wide ungroups data", {
-  data <- dplyr::group_by(pmt_first, SEXf, SEQf)
-  expect_silent(pt_cont_wide(data, cols = "WT, CRCL" ,by = "RF"))
+  data <- dplyr::group_by(pmt_first, CPf, STUDYf)
+  expect_silent(pt_cont_wide(data, cols = "AAG,SCR", by = "ASIAN"))
 })

--- a/tests/testthat/test-cont-table.R
+++ b/tests/testthat/test-cont-table.R
@@ -146,3 +146,13 @@ test_that("pt_cont_x run with no ID column", {
   expect_identical(tab_wide_1$data, tab_wide_2$data)
   expect_identical(tab_long_1$data, tab_long_2$data)
 })
+
+test_that("pt_cont_long ungroups data", {
+  data <- dplyr::group_by(pmt_first, SEXf, SEQf)
+  expect_silent(pt_cont_long(data, cols = "WT, CRCL" ,by = "RF"))
+})
+
+test_that("pt_cont_wide ungroups data", {
+  data <- dplyr::group_by(pmt_first, SEXf, SEQf)
+  expect_silent(pt_cont_wide(data, cols = "WT, CRCL" ,by = "RF"))
+})


### PR DESCRIPTION
Ungroup data coming into  `pt_cont_long()` and `pt_cont_wide()` prior to summarizing. 


```r
> data <- pmt_first %>% group_by(SEXf, SEQf)
> 
> 
> x <- pt_cont_long(data, cols = "WT, CRCL" ,by = "RF")
Adding missing grouping variables: `SEXf`, `SEQf`
Adding missing grouping variables: `SEXf`, `SEQf`
> 
> x <- pt_cont_wide(data, cols = "WT, CRCL" ,by = "RF")
Adding missing grouping variables: `SEXf`, `SEQf`
Adding missing grouping variables: `SEXf`, `SEQf`
```

The pattern I'm using is expected to both ungroup _and_ convert from `tibble` or `data.table` after making sure we do have a data frame. 