### PR TITLE
Refactor sig - big.mark and default maxex

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -39,6 +39,7 @@ cvec_cs <- function(x) {
 #' sig(1.123455, digits = 5)
 #' sig(1123, maxex = 3)
 #' sig(1123, maxex = 4)
+#' sig(1123, big.mark = ",")
 #'
 #' sig(1L)
 #'
@@ -60,10 +61,11 @@ sig <- function(x, digits = 3,
 
   x <- as.numeric(x)
 
-  sigx <- signif(x, digits = 3)
+  sigx <- signif(x, digits = digits)
 
   bigm <- ifelse(is.character(big.mark) && sigx >= 10000, big.mark, "")
 
+  # This adds scientific notation; but also gets zeros right
   ans <- formatC(
     sigx,
     digits = digits,
@@ -72,15 +74,19 @@ sig <- function(x, digits = 3,
     big.mark = bigm
   )
 
+  # This looks for numbers in scientific notation
   if(is.numeric(maxex)) {
     if(digits != maxex) {
       ex <- "([-]*[0-9]\\.[0-9]+)e([+-][0-9]{2})"
-      subit <- grepl(ex, ans, perl = TRUE)
-      b <- as.numeric(gsub(ex, "\\2", ans))
+      subit <- vector(mode = "logical", length = length(ans)) 
+      e <- grepl("e", ans, fixed = TRUE)
+      subit[e] <- grepl(ex, ans[e], perl = TRUE)
+      b <- rep(Inf, length(ans))
+      b[e] <- as.numeric(gsub(ex, "\\2", ans[e]))
       subit <- subit & abs(b) < maxex
-      if(subit) {
-        ans <- formatC(
-          sigx,
+      if(any(subit)) {
+        ans[subit] <- formatC(
+          sigx[subit],
           digits = digits,
           format = "fg",
           flag = "#",

--- a/R/utils.R
+++ b/R/utils.R
@@ -66,16 +66,25 @@ sig <- function(x, digits = 3,
 
   sigx <- signif(x, digits = digits)
 
-  bigm <- ifelse(is.character(big.mark) && sigx >= 10000, big.mark, "")
+  big <- sigx >= 10000
 
   # This adds scientific notation; but also gets zeros right
   ans <- formatC(
     sigx,
     digits = digits,
     format = "g",
-    flag = "#",
-    big.mark = bigm
+    flag = "#"
   )
+
+  if(is.character(big.mark)) {
+    ans[big] <- formatC(
+      sigx[big],
+      digits = digits,
+      format = "g",
+      flag = "#", 
+      big.mark = big.mark
+    )
+  }
 
   # This looks for numbers in scientific notation
   if(is.numeric(maxex)) {
@@ -92,9 +101,17 @@ sig <- function(x, digits = 3,
           sigx[subit],
           digits = digits,
           format = "fg",
-          flag = "#",
-          big.mark = bigm
+          flag = "#"
         )
+        if(is.character(big.mark)) {
+          ans[subit & big] <- formatC(
+            sigx[subit & big],
+            digits = digits,
+            format = "fg",
+            flag = "#", 
+            big.mark = big.mark
+          )
+        }
       }
     }
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -26,6 +26,8 @@ cvec_cs <- function(x) {
 #' @param digits `numeric`; number of significant digits.
 #' @param maxex `numeric`; maximum number of significant
 #' digits before moving to scientific notation.
+#' @param big.mark if `character`, passed to [formatC()], but only for numbers
+#' greater than or equal to 10000 (five digits before decimal).
 #' @param ... other arguments that are not used.
 #'
 #' @return
@@ -46,7 +48,9 @@ cvec_cs <- function(x) {
 #' @md
 #' @rdname sig
 #' @export
-sig <- function(x, digits = 3, maxex = getOption("pmtables.maxex", Inf), ...) {
+sig <- function(x, digits = 3,
+                maxex = getOption("pmtables.maxex", Inf),
+                big.mark = getOption("pmtables.big.mark", NULL), ...) {
 
   if(identical(class(x), "integer")) {
     return(as.character(x))
@@ -58,7 +62,7 @@ sig <- function(x, digits = 3, maxex = getOption("pmtables.maxex", Inf), ...) {
 
   sigx <- signif(x, digits = 3)
 
-  bigm <- ifelse(sigx >= 10000, ",", "")
+  bigm <- ifelse(sigx >= 10000  && is.character(big.mark) , big.mark[1], "")
 
   ans <- formatC(
     sigx,

--- a/R/utils.R
+++ b/R/utils.R
@@ -92,9 +92,10 @@ sig <- function(x, digits = 3,
   # This looks for numbers in scientific notation
   if(is.numeric(maxex)) {
     if(digits != maxex) {
-      ex <- ceiling(abs(log10(abs(sigx))))
+      ex <- log10(abs(sigx))
+      ex <- ifelse(ex < 0, ceiling(abs(ex)), floor(abs(ex)))
       # We revert these numbers back to standard notation
-      subit <- x != 0  & digits < maxex & ex <= maxex
+      subit <- x != 0  & (ex < maxex | (ex >= maxex & ex <= digits))
       if(any(subit)) {
         ans[subit] <- formatC(
           sigx[subit],
@@ -118,6 +119,32 @@ sig <- function(x, digits = 3,
   names(ans) <- namez
   return(ans)
 }
+
+sig_legacy <- function(x, digits = 3, maxex = NULL, ...) {
+
+  if(identical(class(x), "integer")) {
+    return(as.character(x))
+  }
+
+  namez <- names(x)
+
+  x <- as.numeric(x)
+  x <- formatC(signif(x,digits=digits), digits=digits, format='g', flag='#')
+
+  if(is.numeric(maxex)) {
+    if(digits!=maxex) {
+      ex <- "([-]*[0-9]\\.[0-9]+)e([+-][0-9]{2})"
+      subit <- grepl(ex,x,perl=TRUE)
+      b <- as.numeric(gsub(ex, "\\2", x))
+      subit <- subit & abs(b) < maxex
+      x <- ifelse(subit,formatC(signif(as.numeric(x),digits=digits),digits=digits, format="fg",flag="#"),x)
+    }
+  }
+  x <- gsub("\\.$", "", x, perl=TRUE)
+  names(x) <- namez
+  return(x)
+}
+
 
 #' @rdname sig
 #' @export

--- a/R/utils.R
+++ b/R/utils.R
@@ -42,12 +42,12 @@ cvec_cs <- function(x) {
 #' sig(1123, big.mark = ",")
 #' sig(11234, big.mark = ",")
 #' sig(c(1.1,10.1,100.1,1000.1,10000.1), big.mark = ",")
-#' 
+#'
 #'
 #' sig(0)
 #' sig(0L)
 #' sig(1L)
-#' 
+#'
 #' digit1(1.234)
 #' digit1(1321.123)
 #'
@@ -84,7 +84,7 @@ sig <- function(x, digits = 3,
       sigx[big],
       digits = digits,
       format = "g",
-      flag = "#", 
+      flag = "#",
       big.mark = big.mark
     )
   }
@@ -92,13 +92,9 @@ sig <- function(x, digits = 3,
   # This looks for numbers in scientific notation
   if(is.numeric(maxex)) {
     if(digits != maxex) {
-      ex <- "([-]*[0-9]\\.[0-9]+)e([+-][0-9]{2})"
-      subit <- vector(mode = "logical", length = length(ans)) 
-      e <- grepl("e", ans, fixed = TRUE)
-      subit[e] <- grepl(ex, ans[e], perl = TRUE)
-      b <- rep(Inf, length(ans))
-      b[e] <- as.numeric(gsub(ex, "\\2", ans[e]))
-      subit <- subit & abs(b) < maxex
+      ex <- ceiling(abs(log10(abs(sigx))))
+      # We revert these numbers back to standard notation
+      subit <- x!=0  & digits < maxex & ex <= maxex
       if(any(subit)) {
         ans[subit] <- formatC(
           sigx[subit],
@@ -111,7 +107,7 @@ sig <- function(x, digits = 3,
             sigx[subit & big],
             digits = digits,
             format = "fg",
-            flag = "#", 
+            flag = "#",
             big.mark = big.mark
           )
         }

--- a/R/utils.R
+++ b/R/utils.R
@@ -94,7 +94,7 @@ sig <- function(x, digits = 3,
     if(digits != maxex) {
       ex <- ceiling(abs(log10(abs(sigx))))
       # We revert these numbers back to standard notation
-      subit <- x!=0  & digits < maxex & ex <= maxex
+      subit <- x != 0  & digits < maxex & ex <= maxex
       if(any(subit)) {
         ans[subit] <- formatC(
           sigx[subit],

--- a/R/utils.R
+++ b/R/utils.R
@@ -46,7 +46,7 @@ cvec_cs <- function(x) {
 #' @md
 #' @rdname sig
 #' @export
-sig <- function(x, digits = 3, maxex = getOption("pmtables.maxex", NULL), ...) {
+sig <- function(x, digits = 3, maxex = getOption("pmtables.maxex", Inf), ...) {
 
   if(identical(class(x), "integer")) {
     return(as.character(x))
@@ -55,20 +55,39 @@ sig <- function(x, digits = 3, maxex = getOption("pmtables.maxex", NULL), ...) {
   namez <- names(x)
 
   x <- as.numeric(x)
-  x <- formatC(signif(x,digits=digits), digits=digits, format='g', flag='#')
+
+  sigx <- signif(x, digits = 3)
+
+  bigm <- ifelse(sigx >= 10000, ",", "")
+
+  ans <- formatC(
+    sigx,
+    digits = digits,
+    format = "g",
+    flag = "#",
+    big.mark = bigm
+  )
 
   if(is.numeric(maxex)) {
-    if(digits!=maxex) {
+    if(digits != maxex) {
       ex <- "([-]*[0-9]\\.[0-9]+)e([+-][0-9]{2})"
-      subit <- grepl(ex,x,perl=TRUE)
-      b <- as.numeric(gsub(ex, "\\2", x))
+      subit <- grepl(ex, ans, perl = TRUE)
+      b <- as.numeric(gsub(ex, "\\2", ans))
       subit <- subit & abs(b) < maxex
-      x <- ifelse(subit,formatC(signif(as.numeric(x),digits=digits),digits=digits, format="fg",flag="#"),x)
+      if(subit) {
+        ans <- formatC(
+          sigx,
+          digits = digits,
+          format = "fg",
+          flag = "#",
+          big.mark = bigm
+        )
+      }
     }
   }
-  x <- gsub("\\.$", "", x, perl=TRUE)
-  names(x) <- namez
-  return(x)
+  ans <- gsub("\\.$", "", ans, perl = TRUE)
+  names(ans) <- namez
+  return(ans)
 }
 
 #' @rdname sig

--- a/R/utils.R
+++ b/R/utils.R
@@ -62,7 +62,7 @@ sig <- function(x, digits = 3,
 
   sigx <- signif(x, digits = 3)
 
-  bigm <- ifelse(sigx >= 10000  && is.character(big.mark) , big.mark[1], "")
+  bigm <- ifelse(is.character(big.mark) && sigx >= 10000, big.mark, "")
 
   ans <- formatC(
     sigx,

--- a/R/utils.R
+++ b/R/utils.R
@@ -92,10 +92,11 @@ sig <- function(x, digits = 3,
   # This looks for numbers in scientific notation
   if(is.numeric(maxex)) {
     if(digits != maxex) {
+      # When x is zero, ex is -Inf and ex2 is Inf
       ex <- log10(abs(sigx))
       ex2 <- ifelse(ex < 0, ceiling(abs(ex)), floor(abs(ex)))
       # We revert these numbers back to standard notation
-      subit <- x != 0  & (ex2 < maxex | (ex2 >= maxex & ex2 < digits))
+      subit <- ex2 < maxex | (ex2 >= maxex & ex2 < digits)
 
       if(any(subit)) {
         ans[subit] <- formatC(

--- a/R/utils.R
+++ b/R/utils.R
@@ -92,11 +92,13 @@ sig <- function(x, digits = 3,
   # This looks for numbers in scientific notation
   if(is.numeric(maxex)) {
     if(digits != maxex) {
-      # When x is zero, ex is -Inf and ex2 is Inf
+      
+      # When x is zero, ex is -Inf and then Inf
       ex <- log10(abs(sigx))
-      ex2 <- ifelse(ex < 0, ceiling(abs(ex)), floor(abs(ex)))
+      ex <- ifelse(ex < 0, ceiling(abs(ex)), floor(abs(ex)))
+
       # We revert these numbers back to standard notation
-      subit <- ex2 < maxex | (ex2 >= maxex & ex2 < digits)
+      subit <- ex < maxex | (ex >= maxex & ex < digits)
 
       if(any(subit)) {
         ans[subit] <- formatC(

--- a/R/utils.R
+++ b/R/utils.R
@@ -26,8 +26,8 @@ cvec_cs <- function(x) {
 #' @param digits `numeric`; number of significant digits.
 #' @param maxex `numeric`; maximum number of significant
 #' digits before moving to scientific notation.
-#' @param big.mark if `character`, passed to [formatC()], but only for numbers
-#' greater than or equal to 10000 (five digits before decimal).
+#' @param big.mark if `character`, passed to [formatC()], but only when
+#' `signif(x, digits = digits)` is greater than or equal to 10000.
 #' @param ... other arguments that are not used.
 #'
 #' @return

--- a/R/utils.R
+++ b/R/utils.R
@@ -69,6 +69,7 @@ sig <- function(x, digits = 3,
   sigx <- signif(x, digits = digits)
 
   big <- sigx >= 10000
+  dobig <- is.character(big.mark) && length(big.mark)==1 && any(big)
 
   # This adds scientific notation; but also gets zeros right
   ans <- formatC(
@@ -78,7 +79,7 @@ sig <- function(x, digits = 3,
     flag = "#"
   )
 
-  if(is.character(big.mark)) {
+  if(dobig) {
     ans[big] <- formatC(
       sigx[big],
       digits = digits,
@@ -105,7 +106,7 @@ sig <- function(x, digits = 3,
           format = "fg",
           flag = "#"
         )
-        if(is.character(big.mark)) {
+        if(dobig) {
           ans[subit & big] <- formatC(
             sigx[subit & big],
             digits = digits,

--- a/R/utils.R
+++ b/R/utils.R
@@ -41,6 +41,8 @@ cvec_cs <- function(x) {
 #' sig(1123, maxex = 4)
 #' sig(1123, big.mark = ",")
 #' sig(11234, big.mark = ",")
+#' sig(c(1.1,10.1,100.1,1000.1,10000.1), big.mark = ",")
+#' 
 #'
 #' sig(0)
 #' sig(0L)

--- a/R/utils.R
+++ b/R/utils.R
@@ -40,9 +40,12 @@ cvec_cs <- function(x) {
 #' sig(1123, maxex = 3)
 #' sig(1123, maxex = 4)
 #' sig(1123, big.mark = ",")
+#' sig(11234, big.mark = ",")
 #'
+#' sig(0)
+#' sig(0L)
 #' sig(1L)
-#'
+#' 
 #' digit1(1.234)
 #' digit1(1321.123)
 #'

--- a/R/utils.R
+++ b/R/utils.R
@@ -93,9 +93,10 @@ sig <- function(x, digits = 3,
   if(is.numeric(maxex)) {
     if(digits != maxex) {
       ex <- log10(abs(sigx))
-      ex <- ifelse(ex < 0, ceiling(abs(ex)), floor(abs(ex)))
+      ex2 <- ifelse(ex < 0, ceiling(abs(ex)), floor(abs(ex)))
       # We revert these numbers back to standard notation
-      subit <- x != 0  & (ex < maxex | (ex >= maxex & ex <= digits))
+      subit <- x != 0  & (ex2 < maxex | (ex2 >= maxex & ex2 < digits))
+
       if(any(subit)) {
         ans[subit] <- formatC(
           sigx[subit],

--- a/R/utils.R
+++ b/R/utils.R
@@ -98,7 +98,7 @@ sig <- function(x, digits = 3,
       ex <- ifelse(ex < 0, ceiling(abs(ex)), floor(abs(ex)))
 
       # We revert these numbers back to standard notation
-      subit <- ex < maxex | (ex >= maxex & ex < digits)
+      subit <- ex < maxex
 
       if(any(subit)) {
         ans[subit] <- formatC(

--- a/man/sig.Rd
+++ b/man/sig.Rd
@@ -48,6 +48,7 @@ sig(0.123455)
 sig(1.123455, digits = 5)
 sig(1123, maxex = 3)
 sig(1123, maxex = 4)
+sig(1123, big.mark = ",")
 
 sig(1L)
 

--- a/man/sig.Rd
+++ b/man/sig.Rd
@@ -50,6 +50,8 @@ sig(1123, maxex = 3)
 sig(1123, maxex = 4)
 sig(1123, big.mark = ",")
 sig(11234, big.mark = ",")
+sig(c(1.1,10.1,100.1,1000.1,10000.1), big.mark = ",")
+
 
 sig(0)
 sig(0L)

--- a/man/sig.Rd
+++ b/man/sig.Rd
@@ -6,7 +6,13 @@
 \alias{rnd}
 \title{Format digits}
 \usage{
-sig(x, digits = 3, maxex = getOption("pmtables.maxex", NULL), ...)
+sig(
+  x,
+  digits = 3,
+  maxex = getOption("pmtables.maxex", Inf),
+  big.mark = getOption("pmtables.big.mark", NULL),
+  ...
+)
 
 digit1(x, ...)
 
@@ -19,6 +25,9 @@ rnd(x, digits = 0, ...)
 
 \item{maxex}{\code{numeric}; maximum number of significant
 digits before moving to scientific notation.}
+
+\item{big.mark}{if \code{character}, passed to \code{\link[=formatC]{formatC()}}, but only for numbers
+greater than or equal to 10000 (five digits before decimal).}
 
 \item{...}{other arguments that are not used.}
 }

--- a/man/sig.Rd
+++ b/man/sig.Rd
@@ -26,8 +26,8 @@ rnd(x, digits = 0, ...)
 \item{maxex}{\code{numeric}; maximum number of significant
 digits before moving to scientific notation.}
 
-\item{big.mark}{if \code{character}, passed to \code{\link[=formatC]{formatC()}}, but only for numbers
-greater than or equal to 10000 (five digits before decimal).}
+\item{big.mark}{if \code{character}, passed to \code{\link[=formatC]{formatC()}}, but only when
+\code{signif(x, digits = digits)} is greater than or equal to 10000.}
 
 \item{...}{other arguments that are not used.}
 }

--- a/man/sig.Rd
+++ b/man/sig.Rd
@@ -49,7 +49,10 @@ sig(1.123455, digits = 5)
 sig(1123, maxex = 3)
 sig(1123, maxex = 4)
 sig(1123, big.mark = ",")
+sig(11234, big.mark = ",")
 
+sig(0)
+sig(0L)
 sig(1L)
 
 digit1(1.234)

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -149,4 +149,11 @@ test_that("sig behavior - big.mark", {
   expect_equal(c1, "0.0000123")
   c2 <- sig(0.000012345, digits = 3, big.mark = ",")
   expect_equal(c1, c2)
+
+})
+
+test_that("sig big.mark handles vector", {
+  x <- c(0.1, 1, 10, 100, 1000, 10000, 100000)
+  a <- sig(x, big.mark = ",")
+  expect_equal(a, c("0.100", "1.00", "10.0", "100", "1000", "10,000", "100,000"))
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -96,11 +96,57 @@ test_that("sig returns character when passed int [PMT-UTIL-0001]", {
 
 test_that("set maxex via option", {
   a <- sig(123455666)
-  expect_equal(a, "1.23e+08")
-  options(pmtables.maxex = Inf)
+  expect_equal(a, "123000000")
+  options(pmtables.maxex = 2)
   b <- sig(123455666)
-  expect_equal(b, "123000000")
+  expect_equal(b, "1.23e+08")
   options(pmtables.maxex = NULL)
   c <- sig(123455666)
   expect_identical(a, c)
+})
+
+test_that("sig behavior - maxex", {
+  a <- sig(123455666)
+  expect_equal(a, "123000000")
+  aa <- sig(123455666, maxex = 7)
+  expect_equal(aa, "1.23e+08")
+  ab <- sig(123455666, maxex = 8)
+  expect_equal(ab, "1.23e+08")
+  ac <- sig(123455666, maxex = 9)
+  expect_equal(ac, "123000000")
+})
+
+test_that("sig behavior - zero", {
+  a <- sig(0, digits = 3)
+  expect_equal(a, "0.00")
+  b <- sig(0, digits = 4)
+  expect_equal(b, "0.000")
+  d <- sig(as.double(0), digits = 3)
+  expect_equal(d, a)
+  e <- sig(0L)
+  expect_equal(e, "0")
+})
+
+test_that("sig behavior - negative numbers", {
+  a <- sig(-101, digits = 3)
+  expect_equal(a, "-101")
+  b <- sig(-1.23, digits = 3)
+  expect_equal(b, "-1.23")
+  c <- sig(-12342, digits = 3)
+  expect_equal(c, "-12300")
+})
+
+test_that("sig behavior - big.mark", {
+  a <- sig(1.2345, digits = 3, big.mark = ",")
+  expect_equal(a, "1.23")
+
+  b1 <- sig(12345, digits = 3)
+  expect_equal(b1, "12300")
+  b2 <- sig(12345, digits = 3, big.mark = ",")
+  expect_equal(b2, "12,300")
+
+  c1 <- sig(0.000012345, digits = 3)
+  expect_equal(c1, "0.0000123")
+  c2 <- sig(0.000012345, digits = 3, big.mark = ",")
+  expect_equal(c1, c2)
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -192,10 +192,11 @@ test_that("sig compare to legacy", {
 
 test_that("sig compare to legacy - large random tests", {
   set.seed(12323)
-  x <- runif(1000, -3e4, 3e4)
-  y <- runif(1000, -3, 3)
-  z <- runif(1000, -0.001, 0.001)
-  xyz <- c(x, y, z)
+  x  <- runif(1000, -3e6, 3e6)
+  xx <- runif(1000, -2e4, 2e4)
+  y  <- runif(1000, -3, 3)
+  z  <- runif(1000, -0.001, 0.001)
+  xyz <- c(x, xx, y, z)
 
   a <- sig(xyz,  digits = 3)
   b <- sig0(xyz, digits = 3)
@@ -219,5 +220,17 @@ test_that("sig compare to legacy - large random tests", {
 
   a <- sig(xyz,  digits = 2, maxex = 4)
   b <- sig0(xyz, digits = 2, maxex = 4)
+  expect_equal(a, b)
+
+  a <- sig(xyz,  digits = 3, maxex = 2)
+  b <- sig0(xyz, digits = 3, maxex = 2)
+  expect_equal(a, b)
+
+  a <- sig(xyz,  digits = 5, maxex = 2)
+  b <- sig0(xyz, digits = 5, maxex = 2)
+  expect_equal(a, b)
+
+  a <- sig(xyz,  digits = 2, maxex = 2)
+  b <- sig0(xyz, digits = 2, maxex = 2)
   expect_equal(a, b)
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -180,13 +180,44 @@ test_that("sig compare to legacy", {
   expect_identical(sig(x, digits = 4), sig0(x, digits = 4))
   expect_identical(sig(x, digits = 2), sig0(x, digits = 2))
 
-  expect_identical(sig(x, digits = 4, maxex = 3), sig0(x, digits = 4, maxex = 3))
-  expect_identical(sig(x, digits = 2, maxex = 3), sig0(x, digits = 2, maxex = 3))
-
-  set.seed(12345)
-  x <- runif(1000, -1e3, 1e3)
-  a <- sig(x, digits = 3)
-  b <- sig0(x, digits = 3)
-  expect_identical(a, b)
+  expect_identical(
+    sig(x,  digits = 4, maxex = 3),
+    sig0(x, digits = 4, maxex = 3)
+  )
+  expect_identical(
+    sig(x,  digits = 2, maxex = 3),
+    sig0(x, digits = 2, maxex = 3)
+  )
 })
 
+test_that("sig compare to legacy - large random tests", {
+  set.seed(12323)
+  x <- runif(1000, -3e4, 3e4)
+  y <- runif(1000, -3, 3)
+  z <- runif(1000, -0.001, 0.001)
+  xyz <- c(x, y, z)
+
+  a <- sig(xyz,  digits = 3)
+  b <- sig0(xyz, digits = 3)
+  expect_equal(a, b)
+
+  a <- sig(xyz,  digits = 5)
+  b <- sig0(xyz, digits = 5)
+  expect_equal(a, b)
+
+  a <- sig(xyz,  digits = 2)
+  b <- sig0(xyz, digits = 2)
+  expect_equal(a, b)
+
+  a <- sig(xyz,  digits = 3, maxex = 4)
+  b <- sig0(xyz, digits = 3, maxex = 4)
+  expect_equal(a, b)
+
+  a <- sig(xyz,  digits = 5, maxex = 4)
+  b <- sig0(xyz, digits = 5, maxex = 4)
+  expect_equal(a, b)
+
+  a <- sig(xyz,  digits = 2, maxex = 4)
+  b <- sig0(xyz, digits = 2, maxex = 4)
+  expect_equal(a, b)
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -200,10 +200,7 @@ test_that("sig compare to legacy", {
     sig(x,  digits = 2, maxex = 3),
     sig0(x, digits = 2, maxex = 3)
   )
-})
 
-test_that("exercise 'or' condition of subit evaluation", {
-  # ex will be 3, maxex 3, digits 6
   expect_identical(
     sig(1234,  maxex = 3, digits = 6), 
     sig0(1234, maxex = 3, digits = 6)

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,4 +1,5 @@
 library(testthat)
+library(pmtables)
 
 context("test-utils")
 
@@ -157,3 +158,35 @@ test_that("sig big.mark handles vector", {
   a <- sig(x, big.mark = ",")
   expect_equal(a, c("0.100", "1.00", "10.0", "100", "1000", "10,000", "100,000"))
 })
+
+sig0 <- function(..., maxex = Inf) pmtables:::sig_legacy(..., maxex = maxex)
+test_that("sig compare to legacy", {
+  x <- 123
+  expect_identical(sig(x), sig0(x))
+
+  x <- 123.2556
+  expect_identical(sig(x), sig0(x))
+
+  x <- 12323423.2556
+  expect_identical(sig(x), sig0(x))
+
+  x <- 0.000012345
+  expect_identical(sig(x), sig0(x))
+
+  x <- c(0.00001, 1, 10, 100, 100000)
+  expect_identical(sig(x), sig0(x))
+
+  x <- c(0.00001, 1, 10, 100, 100000)
+  expect_identical(sig(x, digits = 4), sig0(x, digits = 4))
+  expect_identical(sig(x, digits = 2), sig0(x, digits = 2))
+
+  expect_identical(sig(x, digits = 4, maxex = 3), sig0(x, digits = 4, maxex = 3))
+  expect_identical(sig(x, digits = 2, maxex = 3), sig0(x, digits = 2, maxex = 3))
+
+  set.seed(12345)
+  x <- runif(1000, -1e3, 1e3)
+  a <- sig(x, digits = 3)
+  b <- sig0(x, digits = 3)
+  expect_identical(a, b)
+})
+

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -202,6 +202,14 @@ test_that("sig compare to legacy", {
   )
 })
 
+test_that("exercise 'or' condition of subit evaluation", {
+  # ex will be 3, maxex 3, digits 6
+  expect_identical(
+    sig(1234,  maxex = 3, digits = 6), 
+    sig0(1234, maxex = 3, digits = 6)
+  )
+})
+
 test_that("sig compare to legacy - large random tests", {
   set.seed(12323)
   x  <- runif(1000, -3e6, 3e6)

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -159,6 +159,18 @@ test_that("sig big.mark handles vector", {
   expect_equal(a, c("0.100", "1.00", "10.0", "100", "1000", "10,000", "100,000"))
 })
 
+test_that("sig big.mark works with maxex=NULL", {
+  x <- c(1000, 10000, 100000)
+  a <- sig(x, digits = 8, maxex = NULL, big.mark = "_")
+  expect_equal(a, c("1000.0000", "10_000.000", "100_000.00"))
+})
+
+test_that("sig big.mark works with maxex=digits", {
+  x <- c(1000, 10000, 100000)
+  a <- sig(x, digits = 8, maxex = 8, big.mark = " ")
+  expect_equal(a, c("1000.0000", "10 000.000", "100 000.00"))
+})
+
 sig0 <- function(..., maxex = Inf) pmtables:::sig_legacy(..., maxex = maxex)
 test_that("sig compare to legacy", {
   x <- 123


### PR DESCRIPTION
- `maxex` defaults to `Inf`
- Optionally use `big.mark` in `formatC()` only when >= 5 digits
  - Make two passes to properly handle big.mark in a vector

NOTE: I started thinking a bit more about how `formatC()` decides when to put numbers into scientific notation. @kyleam could you look at this and see what you think? So far, it works with the tests I have.  The goal of the update is to get rid of regex to figure out how to render the numbers. 

EDIT: I think I have this nailed down better now; legacy sig added; filled in some tests.


``` r
library(pmtables)

sigg <- function(..., maxex = Inf) pmtables:::sig_legacy(..., maxex = maxex)

sig(1.98765)
#> [1] "1.99"
sig(12.98765)
#> [1] "13.0"
sig(123.98765)
#> [1] "124"
sig(1234.98765)
#> [1] "1230"
sig(9994.9999)
#> [1] "9990"
sig(9995.9999)
#> [1] "10000"
sig(12345.98765)
#> [1] "12300"
sig(123456.98765)
#> [1] "123000"
sig(1234567.98765)
#> [1] "1230000"

sig(123, digits = 3)
#> [1] "123"
sig(1234, digits = 3, maxex = Inf)
#> [1] "1230"
sig(1234, digits = 3, maxex = 2)
#> [1] "1230"
sig(1234, digits = 3, maxex = 3)
#> [1] "1.23e+03"
sig(1234, digits = 3, maxex = 4)
#> [1] "1230"


x <- c(0.1, 1, 10, 100, 1000, 10000)
sig(x, maxex = 3)
#> [1] "0.100"    "1.00"     "10.0"     "100"      "1.00e+03" "1.00e+04"
sig(x, maxex = 3, digits = 2)
#> [1] "0.10"    "1.0"     "10"      "100"     "1.0e+03" "1.0e+04"
sigg(x, maxex = 3, digits = 2)
#> [1] "0.10"    "1.0"     "10"      "100"     "1.0e+03" "1.0e+04"


sig(0.01234567)
#> [1] "0.0123"
sig(0.001234567)
#> [1] "0.00123"
sig(0.0001234567)
#> [1] "0.000123"
sig( 0.00001234567)
#> [1] "0.0000123"
sigg(0.00001234567)
#> [1] "0.0000123"
sigg(0.00000000012321)
#> [1] "0.000000000123"
sig(0.00000000012321)
#> [1] "0.000000000123"

sig(0.000001234567)
#> [1] "0.00000123"
sig(0.00001234567, maxex = 5)
#> [1] "1.23e-05"
sig(0.00001234567, maxex = 6)
#> [1] "0.0000123"


sig(1234567.98765, maxex = 4, big.mark = ",")
#> [1] "1.23e+06"
sig(1234567.98765, maxex = 5, big.mark = ",")
#> [1] "1.23e+06"
sig(1234567.98765, maxex = 6, big.mark = ",")
#> [1] "1.23e+06"
sig(1234567.98765, maxex = 7, big.mark = ",")
#> [1] "1,230,000"
x <- c(1,10,100,1000,10000)
sig(x, big.mark = ",")
#> [1] "1.00"   "10.0"   "100"    "1000"   "10,000"

sig(0.1234567, maxex = 1)
#> [1] "0.123"
sig(0.1234567, maxex = 7)
#> [1] "0.123"
sig(0.000001234567, maxex = 6)
#> [1] "1.23e-06"
sig(0.000001234567, maxex = 7)
#> [1] "0.00000123"
sig(0.1234567, maxex = 70)
#> [1] "0.123"
```

<sup>Created on 2026-04-13 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>