### PR TITLE
Document global options

### DIFF
--- a/R/AAAA.R
+++ b/R/AAAA.R
@@ -195,7 +195,27 @@ find_cached_root <- function() {
 #' - [pmt_first] - this is [analysis1] but with only the first record from
 #'   each individual
 #' - [pmt_summarized] - an example data set that has been summarized
-#
+#' 
+#' @section Package options: 
+#' - `mrg.id_col`: column name for unique subject identifier; defaults to 
+#'   `"ID"`; used by various summary table functions.
+#' - `mrg.script`: current script name used for generating table source
+#'   code annotation.
+#' - `pmtables.dir`: default directory used for saving table outputs and 
+#'   generating table source file annotation.
+#' - `pmtables.path.type`: specify formatting for `path` in table source file 
+#'   annotation; see [format_table_path()] for details.
+#' - `pmtables.maxex`: controls when numbers will or won't be rendered with 
+#'   scientific notation by [sig()].
+#' - `pmtables.big.mark`: used by [sig()] when formatting numbers; see 
+#'   [formatC()].
+#' - `pmtables.textwidth`: used when formatting a standalone table preview via
+#'   [st_aspng()] or [st_aspdf()].
+#' - `pmtables.image.border`: used for image border when formatting a standalone
+#'   table preview; see [st_aspng()], [st_aspdf()], and [st_as_image()].
+#' - `pmtables.image.width`: see [st_image_show()] and [st_as_image()].
+#' - `pmtables.image.ltversion`: long-table version; used when formatting a 
+#'   standalone table preview via [st_to_standalone()].
 #'
 #' @md
 #' @name pmtables

--- a/R/AAAA.R
+++ b/R/AAAA.R
@@ -207,15 +207,17 @@ find_cached_root <- function() {
 #'   annotation; see [format_table_path()] for details.
 #' - `pmtables.maxex`: controls when numbers will or won't be rendered with 
 #'   scientific notation by [sig()].
-#' - `pmtables.big.mark`: used by [sig()] when formatting numbers; see 
+#' - `pmtables.big.mark`: used by [sig()] when formatting numbers; passed to 
 #'   [formatC()].
-#' - `pmtables.textwidth`: used when formatting a standalone table preview via
+#' - `pmtables.textwidth`: used when formatting a standalone table preview; see
 #'   [st_aspng()] or [st_aspdf()].
-#' - `pmtables.image.border`: used for image border when formatting a standalone
+#' - `pmtables.image.border`: used when formatting a standalone
 #'   table preview; see [st_aspng()], [st_aspdf()], and [st_as_image()].
 #' - `pmtables.image.width`: see [st_image_show()] and [st_as_image()].
 #' - `pmtables.image.ltversion`: long-table version; used when formatting a 
 #'   standalone table preview via [st_to_standalone()].
+#' - `pmtables.escape`: characters to escape in prepraration for render with 
+#'   `LaTex`; used by [tab_prime()] and [tab_escape()].
 #'
 #' @md
 #' @name pmtables

--- a/R/preview-standalone.R
+++ b/R/preview-standalone.R
@@ -258,7 +258,7 @@ st_aspng <- function(x,
                      stem = "pmt-standalone-preview",
                      dir = tempdir(),
                      font = "helvetica",
-                     textwidth = getOption("pmtables.text.width", 6.5),
+                     textwidth = getOption("pmtables.textwidth", 6.5),
                      border = getOption("pmtables.image.border", "0.2cm 0.7cm"),
                      ntex = 1, dpi = 200) {
   assert_that(inherits(x, "stable"))

--- a/man/pmtables.Rd
+++ b/man/pmtables.Rd
@@ -205,15 +205,17 @@ generating table source file annotation.
 annotation; see \code{\link[=format_table_path]{format_table_path()}} for details.
 \item \code{pmtables.maxex}: controls when numbers will or won't be rendered with
 scientific notation by \code{\link[=sig]{sig()}}.
-\item \code{pmtables.big.mark}: used by \code{\link[=sig]{sig()}} when formatting numbers; see
+\item \code{pmtables.big.mark}: used by \code{\link[=sig]{sig()}} when formatting numbers; passed to
 \code{\link[=formatC]{formatC()}}.
-\item \code{pmtables.textwidth}: used when formatting a standalone table preview via
+\item \code{pmtables.textwidth}: used when formatting a standalone table preview; see
 \code{\link[=st_aspng]{st_aspng()}} or \code{\link[=st_aspdf]{st_aspdf()}}.
-\item \code{pmtables.image.border}: used for image border when formatting a standalone
+\item \code{pmtables.image.border}: used when formatting a standalone
 table preview; see \code{\link[=st_aspng]{st_aspng()}}, \code{\link[=st_aspdf]{st_aspdf()}}, and \code{\link[=st_as_image]{st_as_image()}}.
 \item \code{pmtables.image.width}: see \code{\link[=st_image_show]{st_image_show()}} and \code{\link[=st_as_image]{st_as_image()}}.
 \item \code{pmtables.image.ltversion}: long-table version; used when formatting a
 standalone table preview via \code{\link[=st_to_standalone]{st_to_standalone()}}.
+\item \code{pmtables.escape}: characters to escape in prepraration for render with
+\code{LaTex}; used by \code{\link[=tab_prime]{tab_prime()}} and \code{\link[=tab_escape]{tab_escape()}}.
 }
 }
 

--- a/man/pmtables.Rd
+++ b/man/pmtables.Rd
@@ -192,6 +192,31 @@ each individual
 }
 }
 
+\section{Package options}{
+
+\itemize{
+\item \code{mrg.id_col}: column name for unique subject identifier; defaults to
+\code{"ID"}; used by various summary table functions.
+\item \code{mrg.script}: current script name used for generating table source
+code annotation.
+\item \code{pmtables.dir}: default directory used for saving table outputs and
+generating table source file annotation.
+\item \code{pmtables.path.type}: specify formatting for \code{path} in table source file
+annotation; see \code{\link[=format_table_path]{format_table_path()}} for details.
+\item \code{pmtables.maxex}: controls when numbers will or won't be rendered with
+scientific notation by \code{\link[=sig]{sig()}}.
+\item \code{pmtables.big.mark}: used by \code{\link[=sig]{sig()}} when formatting numbers; see
+\code{\link[=formatC]{formatC()}}.
+\item \code{pmtables.textwidth}: used when formatting a standalone table preview via
+\code{\link[=st_aspng]{st_aspng()}} or \code{\link[=st_aspdf]{st_aspdf()}}.
+\item \code{pmtables.image.border}: used for image border when formatting a standalone
+table preview; see \code{\link[=st_aspng]{st_aspng()}}, \code{\link[=st_aspdf]{st_aspdf()}}, and \code{\link[=st_as_image]{st_as_image()}}.
+\item \code{pmtables.image.width}: see \code{\link[=st_image_show]{st_image_show()}} and \code{\link[=st_as_image]{st_as_image()}}.
+\item \code{pmtables.image.ltversion}: long-table version; used when formatting a
+standalone table preview via \code{\link[=st_to_standalone]{st_to_standalone()}}.
+}
+}
+
 \seealso{
 Useful links:
 \itemize{

--- a/man/st_aspng.Rd
+++ b/man/st_aspng.Rd
@@ -10,7 +10,7 @@ st_aspng(
   stem = "pmt-standalone-preview",
   dir = tempdir(),
   font = "helvetica",
-  textwidth = getOption("pmtables.text.width", 6.5),
+  textwidth = getOption("pmtables.textwidth", 6.5),
   border = getOption("pmtables.image.border", "0.2cm 0.7cm"),
   ntex = 1,
   dpi = 200
@@ -21,7 +21,7 @@ st2png(
   stem = "pmt-standalone-preview",
   dir = tempdir(),
   font = "helvetica",
-  textwidth = getOption("pmtables.text.width", 6.5),
+  textwidth = getOption("pmtables.textwidth", 6.5),
   border = getOption("pmtables.image.border", "0.2cm 0.7cm"),
   ntex = 1,
   dpi = 200


### PR DESCRIPTION
Add list of global options used by `pmtables`; accessible via `?pmtables`.

One option was inadvertently listed as `pmtables.text.width`; I think this was supposed to be `textwidth`; makes more sense. Update highly unlikely to affect anything. 