### PR TITLE
sig: restore handling of NA values

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -68,7 +68,7 @@ sig <- function(x, digits = 3,
 
   sigx <- signif(x, digits = digits)
 
-  big <- sigx >= 10000
+  big <- sigx >= 10000 & !is.na(sigx)
   dobig <- is.character(big.mark) && length(big.mark)==1 && any(big)
 
   # This adds scientific notation; but also gets zeros right
@@ -99,6 +99,7 @@ sig <- function(x, digits = 3,
 
       # We revert these numbers back to standard notation
       subit <- ex < maxex
+      subit <- subit & !is.na(subit)
 
       if(any(subit)) {
         ans[subit] <- formatC(

--- a/R/utils.R
+++ b/R/utils.R
@@ -78,6 +78,8 @@ sig <- function(x, digits = 3,
     format = "g",
     flag = "#"
   )
+  # Revert the left-padded "NA" string returned by formatC.
+  ans[is.na(sigx)] <- NA_character_
 
   if(dobig) {
     ans[big] <- formatC(

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -251,3 +251,20 @@ test_that("sig compare to legacy - large random tests", {
   b <- sig0(xyz, digits = 2, maxex = 2)
   expect_equal(a, b)
 })
+
+test_that("sig handles NAs", {
+  x <- c(NA, 18.155800, 6.317360, 0.898371, NA, NA, 5.275370)
+  a <- sig(x, digits = 2, maxex = 4)
+  expect_equal(
+    a,
+    c(" NA", "18", "6.3", "0.90", " NA", " NA", "5.3")
+  )
+
+  x <- c(12345, NA)
+  a <- sig(x, digits = 3, big.mark = ",")
+  expect_equal(a, c("12,300", "  NA"))
+
+  x <- c(NA_real_, NA_real_)
+  a <- sig(x, digits = 3)
+  expect_equal(a, c("  NA", "  NA"))
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -257,14 +257,14 @@ test_that("sig handles NAs", {
   a <- sig(x, digits = 2, maxex = 4)
   expect_equal(
     a,
-    c(" NA", "18", "6.3", "0.90", " NA", " NA", "5.3")
+    c(NA_character_, "18", "6.3", "0.90", NA_character_, NA_character_, "5.3")
   )
 
   x <- c(12345, NA)
   a <- sig(x, digits = 3, big.mark = ",")
-  expect_equal(a, c("12,300", "  NA"))
+  expect_equal(a, c("12,300", NA_character_))
 
   x <- c(NA_real_, NA_real_)
   a <- sig(x, digits = 3)
-  expect_equal(a, c("  NA", "  NA"))
+  expect_equal(a, c(NA_character_, NA_character_))
 })


### PR DESCRIPTION
The new `sig` (gh-378) fails on `NA` input.  This was flagged by pmparams test failures:

```
── Failed tests ─────────────────────────────────────────────────────────────────────────────────────────────────────
Error (test-format_param_table.R:56:3): format_param_table continuous columns expected ouput: shrinkage
<dplyr:::mutate_error/rlang_error/error/condition>
Error in `dplyr::mutate(., shrinkage = if_else(is.na(shrinkage), "-", as.character(pmtables::sig(shrinkage))))`: i In argument: `shrinkage = if_else(is.na(shrinkage), "-", as.character(pmtables::sig(shrinkage)))`.
Caused by error in `ans[subit] <- formatC(sigx[subit], digits = digits, format = "fg", flag = "#")`:
! NAs are not allowed in subscripted assignments
Backtrace:
     ▆
  1. ├─PARAM_TAB_102 %>% ... at test-format_param_table.R:56:3
  2. ├─dplyr::mutate(., shrinkage = if_else(is.na(shrinkage), "-", as.character(pmtables::sig(shrinkage)))) at magrittr/R/pipe.R:136:3
  3. ├─dplyr:::mutate.data.frame(., shrinkage = if_else(is.na(shrinkage), "-", as.character(pmtables::sig(shrinkage)))) at dplyr/R/mutate.R:146:3
  4. │ └─dplyr:::mutate_cols(.data, dplyr_quosures(...), by) at dplyr/R/mutate.R:183:3
  5. │   ├─base::withCallingHandlers(...) at dplyr/R/mutate.R:270:3
  6. │   └─dplyr:::mutate_col(dots[[i]], data, mask, new_columns) at dplyr/R/mutate.R:275:7
  7. │     └─mask$eval_all_mutate(quo) at dplyr/R/mutate.R:392:9
  8. │       └─dplyr (local) eval() at dplyr/R/data-mask.R:117:7
  9. ├─dplyr::if_else(is.na(shrinkage), "-", as.character(pmtables::sig(shrinkage)))
 10. │ └─vctrs::vec_if_else(...) at dplyr/R/if-else.R:75:3
 11. ├─pmtables::sig(shrinkage) at dplyr/R/if-else.R:75:3
 12. └─base::.handleSimpleError(...)
 13.   └─dplyr (local) h(simpleError(msg, call))
 14.     └─rlang::abort(message, class = error_class, parent = parent, call = error_call) at dplyr/R/conditions.R:245:5

Error (test-format_param_table.R:187:3): format_param_table: .maxex produces expected scientific notation
<dplyr:::mutate_error/rlang_error/error/condition>
Error in `dplyr::mutate(., ci = paste0(display_value(lower, .digit, .maxex), ", ", display_value(upper, .digit, .maxex)), ci = dplyr::if_else(fixed, "FIXED", ci), sd = dplyr::case_when(diag & OM & Osd ~ display_value(random_effect_sd, .digit, .maxex), diag & OM & logitOsd ~ display_value(getSD_logitO(.mean = transTHETA, .var = value), .digit, .maxex), TRUE ~ "-"), corr_SD = dplyr::case_when(is.na(corr_SD) ~ "-", TRUE ~ display_value(corr_SD, .digit, .maxex)), value = display_value(value, .digit, .maxex), value = dplyr::case_when(diag &      OM & Osd | diag & OM & logitOsd ~ glue::glue("{value} {parensSQ_se(sd)}"), diag & OM | diag & S & propErr ~ glue::glue("{value} {parensSQ_CV(cv)}"), diag & OM | diag & S & addErrLogDV ~ glue::glue("{value} {parensSQ_CV(cv)}"), !diag & OM ~ glue::glue("{value} {parensSQ_corr(corr_SD)}"), diag & S & addErr ~ glue::glue("{value} {parensSQ_se(corr_SD)}"), !diag & S ~ glue::glue("{value} {parensSQ_corr(corr_SD)}"), TRUE ~ value), shrinkage = dplyr::case_when(is.na(shrinkage) ~ "-", TRUE ~ display_value(shrinkage,      .digit, .maxex)))`: i In argument: `sd = dplyr::case_when(...)`.
Caused by error in `dplyr::case_when()`:
! Failed to evaluate the right-hand side of formula 1.
Caused by error in `ans[subit] <- formatC(sigx[subit], digits = digits, format = "fg", flag = "#")`:
! NAs are not allowed in subscripted assignments

[ FAIL 2 | WARN 0 | SKIP 0 | PASS 259 ]
```

This PR updates the new `sig` implementation to account for `NA`.

The main fix is the first commit: c9d5a92.  The second commit is a change on top that I think is a good idea, but I'm okay dropping it if it seems too risky and we want to stick closer to what the original `sig` implementation returned: 30fecbc (see commit message for details).