### PR TITLE
Release 0.11.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pmtables
 Type: Package
 Title: Tables for Pharmacometrics
-Version: 0.11.0
+Version: 0.11.1
 Authors@R: 
     c(
     person(given = "Kyle",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# pmtables 0.11.1
+
+## Bugs Fixed
+
+- Fixed a bug where `sig()` failed on `NA` input after the 0.11.0 rewrite;
+  `NA` values are now mapped to `NA_character_` (#383).
+
 # pmtables 0.11.0
 
 - `sig()` no longer renders numbers in scientific notation by default; pass


### PR DESCRIPTION
# pmtables 0.11.1

## Bugs Fixed

- Fixed a bug where `sig()` failed on `NA` input after the 0.11.0 rewrite;
  `NA` values are now mapped to `NA_character_` (#383).

