### PR TITLE
Fix longtable hline to work with single- or multi-page outputs

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -49,3 +49,4 @@ vignettes/rename.Rmd
 ^pkgdown$
 ^\.positai$
 ^\.claude$
+^CLAUDE\.md$

--- a/R/table-long.R
+++ b/R/table-long.R
@@ -1,6 +1,6 @@
 
 longtable_head <- function(multicol) {
-  c("\\hline", multicol, "\\endfoot", "\\hline", "\\endlastfoot")
+  c("\\hline", multicol, "\\endfoot", "", "\\endlastfoot")
 }
 
 conditional_macro <- function(macro_name) {
@@ -137,7 +137,7 @@ stable_long.data.frame <- function(data,
   col_space <- gluet("\\setlength{\\tabcolsep}{<x$sizes$col_space>pt} ")
 
   n_col <- x$nc
-  continued <- gluet("\\multicolumn{<n_col>}{r}{<lt_continue>}")
+  continued <- gluet("\\multicolumn{<n_col>}{r}{<lt_continue>} \\\\")
   head <- longtable_head(continued)
 
   lt_notes <- longtable_notes(x$mini_notes)
@@ -160,6 +160,7 @@ stable_long.data.frame <- function(data,
     x$head_rows,
     "\\endhead",
     x$tab,
+    "\\hline",
     "\\end{longtable}",
     lt_notes,
     x$sizes$font_size$end

--- a/tests/testthat/test-longtable.R
+++ b/tests/testthat/test-longtable.R
@@ -137,9 +137,9 @@ test_that("top hlines are in the head of longtable gh-388", {
   expect_false(grepl("hline", tab[w+1]))
 })
 
-test_that("no explicit trailing hline in longtable gh-388", {
+test_that("no explicit trailing hline in longtable gh-388 and gh-391", {
   tab <- stable_long(stdata())
-  w <- grep("end{longtable}", tab, fixed = TRUE)
+  w <- grep("endlastfoot", tab, fixed = TRUE)
   expect_false(grepl("hline", tab[w-1]))
 })
 


### PR DESCRIPTION
A change was made in #389 to remove extra hline at the end of longtable. That change worked fine for pdf outputs, but we don't see the bottom table line when rendering to standalone preview. 

This PR makes another update that I believe works with both pdf and png outputs. 

1. Remove `\\hline` from `\\endlasthead`
2. Force `\\hline` before closing the longtable
3. There is also a `\\` added for the continuation statement


```r
library(dplyr)
library(pmtables)


tab <- stdata() %>% st_new() %>% st_notes("dfd") %>% st_notes_detach()
tab <- stable_long(tab)

st_as_image(tab, ntex = 3)
st2report(tab, ntex = 3)

a <- stable_save_image(
  tab,
  dir = tempdir(),
  stem = "foo",
  ntex = 3
)

file.show(a)

```