### PR TITLE
use latexmk to automate multiple builds

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -56,7 +56,7 @@ jobs:
           upgrade: ${{ matrix.config.pinned && 'FALSE' || 'TRUE' }}
       - name: Install other system dependencies
         shell: bash
-        run: sudo apt-get install dvipng texlive-latex-base texlive-fonts-extra
+        run: sudo apt-get install dvipng latexmk texlive-latex-base texlive-fonts-extra
       - uses: r-lib/actions/check-r-package@v2
       - name: Check pkgdown
         # The pkgdown in the repo for 3.6.3 does not check_pkgdown.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,6 +55,7 @@ Collate:
     'discrete_table.R'
     'glossary.R'
     'knit-dependencies.R'
+    'latexmk.R'
     'preview-standalone.R'
     'preview.R'
     'summarize-cat-chunk.R'

--- a/R/AAAA.R
+++ b/R/AAAA.R
@@ -122,9 +122,9 @@ find_cached_root <- function() {
 #' @section Preview tables:
 #' - Use [st2viewer()] to send s-table output to [texPreview::tex_preview()]
 #' - Use [st2article()] or [st2report()] to render several tables in
-#'   a stand-alone tex document rendered directly by `pdflatex` (no involvement
-#'   of `Rmarkdown` or `pandoc`); this requires `pdflatex` to be installed and
-#'   in your `PATH`.
+#'   a stand-alone tex document rendered by `pdflatex` driven by `latexmk` (no
+#'   involvement of `Rmarkdown` or `pandoc`); this requires `latexmk` and
+#'   `pdflatex` to be installed and in your `PATH`.
 #' - Use [st2doc()] to render a pdf file with one or more tables using pandoc;
 #'   in general, use [st2article()] instead
 #' - Pipe tables to [st_asis()] to render a table in line while knitting an

--- a/R/latexmk.R
+++ b/R/latexmk.R
@@ -1,0 +1,46 @@
+#' Generate document with `latexmk`
+#'
+#' @param inputfile Input file name for document (with or without trailing
+#'   ".tex")
+#' @param name Use this as the base name for output files rather than taking it
+#'   from `inputfile`.
+#' @param command Which command `latexmk` should call underneath.
+#' @param ... Arguments passed to `system2()`.
+#' @noRd
+latexmk <- function(
+  inputfile,
+  name = NULL,
+  command = c("pdflatex", "latex"),
+  ...
+) {
+  command <- match.arg(command)
+
+  prog <- "latexmk"
+  if (!nzchar(Sys.which(prog))) {
+    rlang::abort(paste(prog, "is required but not in PATH"))
+  }
+
+  args <- c("-halt-on-error", "-interaction=nonstopmode", "-g")
+  if (identical(command, "pdflatex")) {
+    args <- c(args, "-pdf")
+  } else if (identical(command, "latex")) {
+    args <- c(args, "-latex")
+  } else {
+    rlang::abort(paste("bug: unknown command:", command))
+  }
+
+  if (!is.null(name)) {
+    args <- c(args, paste0("-jobname=", shQuote(name)))
+  }
+  system2(prog, c(args, shQuote(inputfile)), ...)
+}
+
+warn_ntex <- function(call = rlang::caller_env()) {
+  rlang::warn(
+    c(
+      "'ntex' argument is ignored.",
+      "i" = "Output is built with `latexmk`, which reruns the tex engine as needed."
+    ),
+    call = call
+  )
+}

--- a/R/preview-standalone.R
+++ b/R/preview-standalone.R
@@ -60,11 +60,13 @@ st_to_standalone <- function(text, stem, dir,
                              border = "0.2cm 1cm",
                              ntex = 1,
                              ltversion = getOption("pmtables.image.ltversion" , 4.13)) {
+  if (!missing(ntex)) {
+    warn_ntex()
+  }
 
   out_ext <- ifelse(command=="latex", ".dvi", ".pdf")
   font <- match.arg(font)
   assert_that(is.character(border) && length(border)==1)
-  assert_that(is.numeric(ntex) && length(ntex)==1)
   assert_that(is.numeric(ltversion))
 
   if(!dir.exists(dir)) dir.create(dir)
@@ -112,20 +114,7 @@ st_to_standalone <- function(text, stem, dir,
   writeLines(temp_text, con = build_file)
   writeLines(text, con = texfile)
 
-  args <- c(
-    "-halt-on-error",
-    paste0("-jobname=", stem),
-    build_file
-  )
-
-  for(i in seq(ntex)) {
-    x <- system2(
-      command = command,
-      args = args,
-      stdout = TRUE,
-      stderr = TRUE
-    )
-  }
+  latexmk(build_file, name = stem, command = command, stdout = FALSE, stderr = FALSE)
 
   ans <- file.path(dir, outfile)
   if(!file.exists(outfile)) {
@@ -176,8 +165,9 @@ st_to_standalone <- function(text, stem, dir,
 #'
 #' @examples
 #'
-#' # check that pdflatex is installed
+#' # check that latexmk and pdflatex are installed
 #' \dontrun{
+#' Sys.which("latexmk")
 #' Sys.which("pdflatex")
 #' }
 #'
@@ -204,6 +194,10 @@ st_aspdf <- function(x,
                      textwidth = getOption("pmtables.textwidth", 6.5),
                      border = getOption("pmtables.image.border", "0.2cm 0.7cm"),
                      ntex = 1) {
+  if (!missing(ntex)) {
+    warn_ntex()
+  }
+
   assert_that(inherits(x, "stable"))
   ans <- st_to_standalone(
     x,
@@ -212,8 +206,7 @@ st_aspdf <- function(x,
     command = "pdflatex",
     font = font,
     textwidth = textwidth,
-    border = border,
-    ntex = ntex
+    border = border
   )
   if(inherits(ans, "latex-failed")) {
     fail_pdf(unclass(ans))
@@ -239,6 +232,7 @@ st2pdf <- st_aspdf
 #'
 #' @examples
 #' \dontrun{
+#' Sys.which("latexmk")
 #' Sys.which("latex")
 #' Sys.which("dvipng")
 #'
@@ -261,6 +255,10 @@ st_aspng <- function(x,
                      textwidth = getOption("pmtables.textwidth", 6.5),
                      border = getOption("pmtables.image.border", "0.2cm 0.7cm"),
                      ntex = 1, dpi = 200) {
+  if (!missing(ntex)) {
+    warn_ntex()
+  }
+
   assert_that(inherits(x, "stable"))
   outfile <- st_to_standalone(
     x,
@@ -269,8 +267,7 @@ st_aspng <- function(x,
     command = "latex",
     font = font,
     textwidth = textwidth,
-    border = border,
-    ntex = ntex
+    border = border
   )
   png_file <- sub("dvi$", "png", outfile, perl = TRUE)
   if(inherits(outfile, "latex-failed")) {

--- a/R/preview.R
+++ b/R/preview.R
@@ -136,7 +136,9 @@ st2viewer <- function(...) st_preview(...)
 #'
 #' @param ... stable objects
 #' @param .list a list of stable objects
-#' @param ntex number of times to build the pdf file
+#' @param ntex **Deprecated**. This argument no longer has an effect. Underneath,
+#'   `latexmk` is used to run the underlying command (e.g., `pdflatex`) as many
+#'   times as required.
 #' @param stem name for the article file, without extension
 #' @param output_dir the output directory for the rendered pdf file
 #' @param margin the page margins; this must be a character vector of length
@@ -210,6 +212,10 @@ st2article <- function(..., .list = NULL, ntex = 1,  #nocov start
                        output_dir = tempdir(), template = NULL,
                        margin = c("2.54cm", "3cm"), caption = NULL,
                        dry_run = FALSE, stdout = FALSE, show_pdf = TRUE) {
+  if (!missing(ntex)) {
+    warn_ntex()
+  }
+
   tables <- c(list(...),.list)
   tables <- list_flatten(tables)
   names(tables) <- tab_escape(names(tables))
@@ -300,14 +306,9 @@ st2article <- function(..., .list = NULL, ntex = 1,  #nocov start
   }
 
   if(file.exists(texfile)) {
-    for(i in seq_len(ntex)) {
-      result <- system2(
-        "pdflatex",
-        args=c("-halt-on-error ",texfile), stdout = stdout
-      )
-      if(!identical(result, 0L)) {
-        warning("non-zero exit from pdflatex", call.=FALSE)
-      }
+    result <- latexmk(texfile, command = "pdflatex", stdout = stdout)
+    if (!identical(result, 0L)) {
+      warning("non-zero exit from latexmk", call. = FALSE)
     }
   } else {
     stop(

--- a/R/table-long.R
+++ b/R/table-long.R
@@ -83,9 +83,6 @@ longtable_notes <- function(notes) {
 #' get inserted **inside** the `longtable` environment; this is why you see
 #' several additional arguments for [stable_long()].
 #'
-#' You may have to run `pdflatex` on your `longtable` more than once to get the
-#' table to render properly; this is not unexpected behavior for `longtable`.
-#'
 #' If you have panels in your table, the default is to prevent page breaks
 #' right after the panel title row using the `\\*` command in the `longtable`
 #' package. This shouldn't need to be changed by the user, but if needed this

--- a/man/pmtables.Rd
+++ b/man/pmtables.Rd
@@ -102,9 +102,9 @@ horizontal line above
 \itemize{
 \item Use \code{\link[=st2viewer]{st2viewer()}} to send s-table output to \code{\link[texPreview:tex_preview]{texPreview::tex_preview()}}
 \item Use \code{\link[=st2article]{st2article()}} or \code{\link[=st2report]{st2report()}} to render several tables in
-a stand-alone tex document rendered directly by \code{pdflatex} (no involvement
-of \code{Rmarkdown} or \code{pandoc}); this requires \code{pdflatex} to be installed and
-in your \code{PATH}.
+a stand-alone tex document rendered by \code{pdflatex} driven by \code{latexmk} (no
+involvement of \code{Rmarkdown} or \code{pandoc}); this requires \code{latexmk} and
+\code{pdflatex} to be installed and in your \code{PATH}.
 \item Use \code{\link[=st2doc]{st2doc()}} to render a pdf file with one or more tables using pandoc;
 in general, use \code{\link[=st2article]{st2article()}} instead
 \item Pipe tables to \code{\link[=st_asis]{st_asis()}} to render a table in line while knitting an

--- a/man/st2article.Rd
+++ b/man/st2article.Rd
@@ -32,7 +32,9 @@ st2report(
 
 \item{.list}{a list of stable objects}
 
-\item{ntex}{number of times to build the pdf file}
+\item{ntex}{\strong{Deprecated}. This argument no longer has an effect. Underneath,
+\code{latexmk} is used to run the underlying command (e.g., \code{pdflatex}) as many
+times as required.}
 
 \item{stem}{name for the article file, without extension}
 

--- a/man/st_aspdf.Rd
+++ b/man/st_aspdf.Rd
@@ -42,7 +42,9 @@ passed to \code{\link[=st_to_standalone]{st_to_standalone()}}; see details.}
 \item{border}{passed as an option to \code{standalone} latex output type; see
 details.}
 
-\item{ntex}{number of times to build the pdf file}
+\item{ntex}{\strong{Deprecated}. This argument no longer has an effect. Underneath,
+\code{latexmk} is used to run the underlying command (e.g., \code{pdflatex}) as many
+times as required.}
 }
 \value{
 A string containing the path to the rendered \code{pdf} file.
@@ -73,8 +75,9 @@ for the left, bottom, right and top (see the documentation for the
 }
 \examples{
 
-# check that pdflatex is installed
+# check that latexmk and pdflatex are installed
 \dontrun{
+Sys.which("latexmk")
 Sys.which("pdflatex")
 }
 

--- a/man/st_aspng.Rd
+++ b/man/st_aspng.Rd
@@ -44,7 +44,9 @@ passed to \code{\link[=st_to_standalone]{st_to_standalone()}}; see details.}
 \item{border}{passed as an option to \code{standalone} latex output type; see
 details.}
 
-\item{ntex}{number of times to build the pdf file}
+\item{ntex}{\strong{Deprecated}. This argument no longer has an effect. Underneath,
+\code{latexmk} is used to run the underlying command (e.g., \code{pdflatex}) as many
+times as required.}
 
 \item{dpi}{dots per inch for the resulting \code{png} file; used by \code{dvipng} when
 converting \code{dvi} file to the final \code{png} result.}
@@ -60,6 +62,7 @@ is returned. \code{st2png()} is an alias to \code{st_as_png()}.
 }
 \examples{
 \dontrun{
+Sys.which("latexmk")
 Sys.which("latex")
 Sys.which("dvipng")
 

--- a/man/st_to_standalone.Rd
+++ b/man/st_to_standalone.Rd
@@ -35,7 +35,9 @@ passed to \code{\link[=st_to_standalone]{st_to_standalone()}}; see details.}
 \item{border}{passed as an option to \code{standalone} latex output type; see
 details.}
 
-\item{ntex}{number of times to build the pdf file}
+\item{ntex}{\strong{Deprecated}. This argument no longer has an effect. Underneath,
+\code{latexmk} is used to run the underlying command (e.g., \code{pdflatex}) as many
+times as required.}
 
 \item{ltversion}{numeric version number for the longtable package; newer
 versions have an issue that will break this code for longtables; so we are

--- a/man/stable_long.Rd
+++ b/man/stable_long.Rd
@@ -70,9 +70,6 @@ between \code{tablular} and \code{longtable} environments is that captions need 
 get inserted \strong{inside} the \code{longtable} environment; this is why you see
 several additional arguments for \code{\link[=stable_long]{stable_long()}}.
 
-You may have to run \code{pdflatex} on your \code{longtable} more than once to get the
-table to render properly; this is not unexpected behavior for \code{longtable}.
-
 If you have panels in your table, the default is to prevent page breaks
 right after the panel title row using the \verb{\\\\*} command in the \code{longtable}
 package. This shouldn't need to be changed by the user, but if needed this

--- a/tests/testthat/image/as-image-test.Rmd
+++ b/tests/testthat/image/as-image-test.Rmd
@@ -64,7 +64,7 @@ st_as_image(tab, dir = dir, stem = "convert-stable")
 ## Convert from long stable
 
 ```{r}
-st_as_image(longtab, dir = dir, stem = "convert-longtable", ntex = 2)
+st_as_image(longtab, dir = dir, stem = "convert-longtable")
 ```
 
 ## Convert from pmtable

--- a/tests/testthat/test-as-image.R
+++ b/tests/testthat/test-as-image.R
@@ -28,7 +28,7 @@ test_that("standalone tex file looks as expected: stable", {
 
 test_that("standalone tex file looks as expected: long stable", {
   longtab <- stable_long(stdata())
-  x <- do(st_as_image, longtab, stem = "convert-longtable", ntex = 2)
+  x <- do(st_as_image, longtab, stem = "convert-longtable")
   expect_match(x, "\\input{convert-longtable.tex}", all = FALSE, fixed = TRUE)
 })
 


### PR DESCRIPTION
Several functions expose an `ntex` argument that callers can override when more than one build is required to reach the final output state. Switch to building with `latexmk` underneath so that the user doesn't need to worry about passing `ntex`.

---

This PR replaces gh-392.

https://github.com/metrumresearchgroup/pmtables/pull/392#issuecomment-5608126803