### PR TITLE
Release/0.12.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pmtables
 Type: Package
 Title: Tables for Pharmacometrics
-Version: 0.11.2
+Version: 0.12.0
 Authors@R: 
     c(
     person(given = "Kyle",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,17 @@
+# pmtables 0.12.0
+
+- Output rendered by `st2article()`, `st2report()`, `st_aspdf()`, and
+  `st_aspng()` is now built with `latexmk`, which reruns the tex engine as many
+  times as needed; these functions now require `latexmk` to be installed and in
+  your `PATH`. The `ntex` argument is deprecated and ignored; passing it results
+  in a warning (#393).
+
+## Bugs Fixed
+
+- Fixed a bug in `stable_long()` where the `\hline` at the bottom of the table
+  was misplaced; tables now get a closing `\hline` on the final page for both
+  single- and multi-page outputs (#391).
+
 # pmtables 0.11.2
 
 ## Bugs Fixed

--- a/R/AAAA.R
+++ b/R/AAAA.R
@@ -215,7 +215,7 @@ find_cached_root <- function() {
 #' - `pmtables.image.width`: see [st_image_show()] and [st_as_image()].
 #' - `pmtables.image.ltversion`: long-table version; used when formatting a 
 #'   standalone table preview via [st_to_standalone()].
-#' - `pmtables.escape`: characters to escape in prepraration for render with 
+#' - `pmtables.escape`: characters to escape in preparation for render with 
 #'   `LaTex`; used by [tab_prime()] and [tab_escape()].
 #'
 #' @md

--- a/man/pmtables.Rd
+++ b/man/pmtables.Rd
@@ -214,7 +214,7 @@ table preview; see \code{\link[=st_aspng]{st_aspng()}}, \code{\link[=st_aspdf]{s
 \item \code{pmtables.image.width}: see \code{\link[=st_image_show]{st_image_show()}} and \code{\link[=st_as_image]{st_as_image()}}.
 \item \code{pmtables.image.ltversion}: long-table version; used when formatting a
 standalone table preview via \code{\link[=st_to_standalone]{st_to_standalone()}}.
-\item \code{pmtables.escape}: characters to escape in prepraration for render with
+\item \code{pmtables.escape}: characters to escape in preparation for render with
 \code{LaTex}; used by \code{\link[=tab_prime]{tab_prime()}} and \code{\link[=tab_escape]{tab_escape()}}.
 }
 }


### PR DESCRIPTION
# pmtables 0.12.0

- Output rendered by `st2article()`, `st2report()`, `st_aspdf()`, and
  `st_aspng()` is now built with `latexmk`, which reruns the tex engine as many
  times as needed; these functions now require `latexmk` to be installed and in
  your `PATH`. The `ntex` argument is deprecated and ignored; passing it results
  in a warning (#393).

## Bugs Fixed

- Fixed a bug in `stable_long()` where the `\hline` at the bottom of the table
  was misplaced; tables now get a closing `\hline` on the final page for both
  single- and multi-page outputs (#391).