### PR TITLE
Reproducible date in latexmk-generated pdf

### DIFF
--- a/R/latexmk.R
+++ b/R/latexmk.R
@@ -32,7 +32,8 @@ latexmk <- function(
   if (!is.null(name)) {
     args <- c(args, paste0("-jobname=", shQuote(name)))
   }
-  system2(prog, c(args, shQuote(inputfile)), ...)
+  env <- c("SOURCE_DATE_EPOCH=1000000000", "FORCE_SOURCE_DATE=1")
+  system2(prog, c(args, shQuote(inputfile)), ..., env = env)
 }
 
 warn_ntex <- function(call = rlang::caller_env()) {

--- a/R/latexmk.R
+++ b/R/latexmk.R
@@ -5,12 +5,15 @@
 #' @param name Use this as the base name for output files rather than taking it
 #'   from `inputfile`.
 #' @param command Which command `latexmk` should call underneath.
-#' @param ... Arguments passed to `system2()`.
+#' @param env Passed to `system2()`. If missing, `SOURCE_DATE_EPOCH`, and
+#' `FORCE_SOURCE_DATE` are set to make a static document timestamp.
+#' @param ... Other arguments passed to `system2()`.
 #' @noRd
 latexmk <- function(
   inputfile,
   name = NULL,
   command = c("pdflatex", "latex"),
+  env = character(),
   ...
 ) {
   command <- match.arg(command)
@@ -33,8 +36,11 @@ latexmk <- function(
     args <- c(args, paste0("-jobname=", shQuote(name)))
   }
 
-  env <- c("SOURCE_DATE_EPOCH=1000000000", "FORCE_SOURCE_DATE=1")
-  system2(prog, c(args, shQuote(inputfile)), ..., env = env)
+  if (missing(env)) {
+    env <- c("SOURCE_DATE_EPOCH=1000000000", "FORCE_SOURCE_DATE=1")
+  }
+
+  system2(prog, c(args, shQuote(inputfile)), env = env, ...)
 }
 
 warn_ntex <- function(call = rlang::caller_env()) {

--- a/R/latexmk.R
+++ b/R/latexmk.R
@@ -32,6 +32,7 @@ latexmk <- function(
   if (!is.null(name)) {
     args <- c(args, paste0("-jobname=", shQuote(name)))
   }
+
   env <- c("SOURCE_DATE_EPOCH=1000000000", "FORCE_SOURCE_DATE=1")
   system2(prog, c(args, shQuote(inputfile)), ..., env = env)
 }


### PR DESCRIPTION
This came up when we were talking about reproducible pdfs coming out of mrggsave. This PR sets environment variables in the `latexmk` `system2()` call to force a static date into the output. These are simple previews, so no meed to expose anything to the user. 

`system2()` env: `character vector of name=value strings to set environment variables.`


1. Do we want to do this in `latexmk()`? 
2. Is this the right way to do it? 

EDIT: tried the environment variables on Metworx and it doesn't seem to work; tests below were on macbook. 

Environment variable workaround proposed in `templates/msproject` ():

```r
Sys.setenv(SOURCE_DATE_EPOCH="1000000000", FORCE_SOURCE_DATE="1")
```





# Output after change

```r
> library(pmtables)
> 
> tab <- stable(stdata())
> 
> st2report(tab, stem = "foo", output_dir = getwd(), show_pdf = FALSE)
> tools::md5sum("foo.pdf")
                           foo.pdf 
"04ca30bed87a594dc6574e337ca128c8" 
> 
> st2report(tab, stem = "foo", output_dir = getwd(), show_pdf = FALSE)
> tools::md5sum("foo.pdf")
                           foo.pdf 
"04ca30bed87a594dc6574e337ca128c8" 
```

# Output before change
```r
> library(pmtables)
> 
> tab <- stable(stdata())
> 
> st2report(tab, stem = "foo", output_dir = getwd(), show_pdf = FALSE)
> tools::md5sum("foo.pdf")
                           foo.pdf 
"2c53123ef804ed7ca36c8dbccd80e686" 
> 
> st2report(tab, stem = "foo", output_dir = getwd(), show_pdf = FALSE)
> tools::md5sum("foo.pdf")
                           foo.pdf 
"8a15325323261b18e0953b717c5c324d" 
```